### PR TITLE
Minor: k3s update from v1.23.3+k3s1 to v1.23.4+k3s1

### DIFF
--- a/inventory/pi-cluster/group_vars/all.yml
+++ b/inventory/pi-cluster/group_vars/all.yml
@@ -3,7 +3,7 @@ ansible_user: charles
 
 k3s_state: installed # 'uninstalled' to uninstall k3s
 k3s_github_url: https://github.com/k3s-io/k3s
-k3s_release_version: v1.23.3+k3s1
+k3s_release_version: v1.23.4+k3s1
 k3s_etcd_datastore: true
 k3s_become_for_all: true
 


### PR DESCRIPTION
This release updates Kubernetes to v1.23.4, and fixes a number of issues.

For more details on what's new, see the [Kubernetes release notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.23.md#changelog-since-v1233).

## Known Issues: 
* There is [an issue](https://github.com/k3s-io/k3s/issues/4023) that may cause unexpected behavior when removing servers running embedded etcd from the cluster. When removing servers with etcd from the
 cluster, ensure that the k3s service is stopped before using `kubectl delete` to remove the node from the Kubernetes and etcd cluster. You should do this one node at a time to ensure that your cluster d
oes not lose quorum. Failure to follow this process may result in K3s on the deleted node crashing, restarting, and rejoining the cluster.

## Changes since v1.23.3+k3s1:

* Updated to V1.23.4 k3s1 and updated traefik to v2.6.1 [(#5135)](https://github.com/k3s-io/k3s/pull/5135)
* Added `--server` flag to `k3s secrets-encrypt` subcommand to enable access non-local and non-default k3s servers. [(#5016)](https://github.com/k3s-io/k3s/pull/5016)
* Fixed to Drone CI Stability [(#4897)](https://github.com/k3s-io/k3s/pull/4897)
* Updated to flannel v0.16.2 [(#5035)](https://github.com/k3s-io/k3s/pull/5035)
* Signed CSRs for legacy-unknown with the server CA [(#5057)](https://github.com/k3s-io/k3s/pull/5057)
* K3s kubectl now no longer outputs a [WARN] log when using the `--kubeconfig` flag [(#5064)](https://github.com/k3s-io/k3s/pull/5064)
* Used kube-router as a library [(#5079)](https://github.com/k3s-io/k3s/pull/5079)
* Updated CentOS 8 smoke vm's with vault repositories [(#5092)](https://github.com/k3s-io/k3s/pull/5092)
* Fixed cluster validation and add upgrade cluster test [(#5020)](https://github.com/k3s-io/k3s/pull/5020)
* Removed all iptables rules when destroying k3s cluster [(#5059)](https://github.com/k3s-io/k3s/pull/5059)
* Added k3s etcd restoration test [(#5014)](https://github.com/k3s-io/k3s/pull/5014)
* Migrated Ginkgo testing framework to V2, consolidate integration tests [(#5097)](https://github.com/k3s-io/k3s/pull/5097)
* E2E Test Improvements [(#5102)](https://github.com/k3s-io/k3s/pull/5102)
* Fixed annoying netpol heartbeat missing log [(#5106)](https://github.com/k3s-io/k3s/pull/5106)
* Fixed a regression that prevented `--disable` from removing previously installed components. [(#5113)](https://github.com/k3s-io/k3s/pull/5113)

## Embedded Component Versions
| Component | Version |
|---|---|
| Kubernetes | [v1.23.4](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.23.md#v1234) |
| Kine | [v0.8.1](https://github.com/k3s-io/kine/releases/tag/v0.8.1) |
| SQLite | [3.36.0](https://sqlite.org/releaselog/3_36_0.html) |
| Etcd | [v3.5.1-k3s1](https://github.com/k3s-io/etcd/releases/tag/v3.5.1-k3s1) |
| Containerd | [v1.5.9-k3s1](https://github.com/k3s-io/containerd/releases/tag/v1.5.9-k3s1) |
| Runc | [v1.0.3](https://github.com/opencontainers/runc/releases/tag/v1.0.3) |
| Flannel | [v0.16.3](https://github.com/flannel-io/flannel/releases/tag/v0.16.3) |
| Metrics-server | [v0.5.2](https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.5.2) |
| Traefik | [v2.6.1](https://github.com/traefik/traefik/releases/tag/v2.6.1) |
| CoreDNS | [v1.8.6](https://github.com/coredns/coredns/releases/tag/v1.8.6) |
| Helm-controller | [v0.11.7](https://github.com/k3s-io/helm-controller/releases/tag/v0.11.7) |
| Local-path-provisioner | [v0.0.21](https://github.com/rancher/local-path-provisioner/releases/tag/v0.0.21) |

## Helpful Links
As always, we welcome and appreciate feedback from our community of users. Please feel free to:
- [Open issues here](https://github.com/rancher/k3s/issues/new/choose)
- [Join our Slack channel](https://slack.rancher.io/)
- [Check out our documentation](https://rancher.com/docs/k3s/latest/en/) for guidance on how to get started or to dive deep into K3s.
- [Read how you can contribute here](https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md)