### PR TITLE
Minor: k3s update from v1.23.4+k3s1 to v1.23.5+k3s1

### DIFF
--- a/inventory/pi-cluster/group_vars/all.yml
+++ b/inventory/pi-cluster/group_vars/all.yml
@@ -3,7 +3,7 @@ ansible_user: charles
 
 k3s_state: installed # 'uninstalled' to uninstall k3s
 k3s_github_url: https://github.com/k3s-io/k3s
-k3s_release_version: v1.23.4+k3s1
+k3s_release_version: v1.23.5+k3s1
 k3s_etcd_datastore: true
 k3s_become: true
 


### PR DESCRIPTION
<!-- v1.23.5+k3s1 -->
This release updates Kubernetes to v1.23.5, and fixes a number of issues.

For more details on what's new, see the [Kubernetes release notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.23.md#changelog-since-v1234).

## Changes since v1.23.4+k3s1:

* Add partial support for IPv6 only mode [(#4450)](https://github.com/k3s-io/k3s/pull/4450)
* Integration tests: move to a global test lock [(#5155)](https://github.com/k3s-io/k3s/pull/5155)
* Fixed a bug that prevented users from using k3s secrets-encryption rotation after upgrading from older K3s versions. [(#5140)](https://github.com/k3s-io/k3s/pull/5140)
* Add ability to specify etcd snapshot list output format [(#5132)](https://github.com/k3s-io/k3s/pull/5132)
* Add `--json` flag for `k3s secrets-encrypt status` [(#5127)](https://github.com/k3s-io/k3s/pull/5127)
* Bump up github.com/containerd/stargz-snapshotter (v0.11.0) [(#5032)](https://github.com/k3s-io/k3s/pull/5032)
* Server nodes with only etcd/control-plane/etcd+control-plane roles can now be added to the cluster in any order, as long as the first node has the etcd role. [(#5143)](https://github.com/k3s-io/k3s/pull/5143)
* Add http/2 support to API server [(#5149)](https://github.com/k3s-io/k3s/pull/5149)
* E2E secrets encryption test [(#5144)](https://github.com/k3s-io/k3s/pull/5144)
* Any alarms present on the embedded etcd datastore are now reported and cleared at startup. This should allow for graceful recovery after exceeding and subsequently raising the etcd quota size. [(#5158)](https://github.com/k3s-io/k3s/pull/5158)
* When using the unsupported `--disable-agent` flag, kube-scheduler will now be started when a node is available. [(#5125)](https://github.com/k3s-io/k3s/pull/5125)
* E2E Add external DB options to ValidateCluster test [(#5157)](https://github.com/k3s-io/k3s/pull/5157)
* [master] changing package to k3s-io [(#4846)](https://github.com/k3s-io/k3s/pull/4846)
* The embedded containerd has been bumped to v1.5.10-k3s1 [(#5201)](https://github.com/k3s-io/k3s/pull/5201)
* The embedded ServiceLB LoadBalancer controller now supports mixed-protocol Services, and will clean up daemonsets when the Service type changes. [(#5205)](https://github.com/k3s-io/k3s/pull/5205)
* Flannel 0.17 [(#5215)](https://github.com/k3s-io/k3s/pull/5215)
* `k3s secrets-encrypt prepare` can now be used on control-plane only nodes [(#5222)](https://github.com/k3s-io/k3s/pull/5222)
* fix function arg call [(#5234)](https://github.com/k3s-io/k3s/pull/5234)
* Added ipv6 only support with flannel [(#5238)](https://github.com/k3s-io/k3s/pull/5238)
* Testing directory and documentation rework. [(#5256)](https://github.com/k3s-io/k3s/pull/5256)
* Fixed a regression present in 1.23 that prevented the embedded kubectl binary from parsing common CLI flags, such as `-v=0 to set verbosity` [(#5270)](https://github.com/k3s-io/k3s/pull/5270)
* The embedded Helm controller can now cease management of existing HelmChart releases, supports setting a failure policy for  install/update operations, and allows trusting custom CA certs for remote chart repositories. [(#5263)](https://github.com/k3s-io/k3s/pull/5263)
* E2E Split Server Test [(#5286)](https://github.com/k3s-io/k3s/pull/5286)
* Replace CentOS 8 with Rocky Linux 8 for install testing [(#5279)](https://github.com/k3s-io/k3s/pull/5279)
* Secondary etcd-only nodes will now successfully bootstrap containerd and the kubelet before a control-plane node has joined the cluster. [(#5300)](https://github.com/k3s-io/k3s/pull/5300)
* Refactor automation using terraform [(#5268)](https://github.com/k3s-io/k3s/pull/5268)
* Update Kubernetes to v1.23.5-k3s1 [(#5271)](https://github.com/k3s-io/k3s/pull/5271)
* The packaged coredns version has been bumped to v1.9.1 [(#5308)](https://github.com/k3s-io/k3s/pull/5308)
* Defragment etcd datastore before clearing alarms; don't delete temp etcd db while reconciling
 * The embedded etcd database is now defragmented on startup.
 * Fixed an issue that could cause restart of managed etcd nodes to occasionally fail while reconciling bootstrap data. [(#5336)](https://github.com/k3s-io/k3s/pull/5336)
* [master] Wrap containerd.New [(#5361)](https://github.com/k3s-io/k3s/pull/5361)

## Embedded Component Versions
| Component | Version |
|---|---|
| Kubernetes | [v1.23.5](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.23.md#v1235) |
| Kine | [v0.8.1](https://github.com/k3s-io/kine/releases/tag/v0.8.1) |
| SQLite | [3.36.0](https://sqlite.org/releaselog/3_36_0.html) |
| Etcd | [v3.5.1-k3s1](https://github.com/k3s-io/etcd/releases/tag/v3.5.1-k3s1) |
| Containerd | [v1.5.10-k3s1](https://github.com/k3s-io/containerd/releases/tag/v1.5.10-k3s1) |
| Runc | [v1.0.3](https://github.com/opencontainers/runc/releases/tag/v1.0.3) |
| Flannel | [v0.17.0](https://github.com/flannel-io/flannel/releases/tag/v0.17.0) | 
| Metrics-server | [v0.5.2](https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.5.2) |
| Traefik | [v2.6.1](https://github.com/traefik/traefik/releases/tag/v2.6.1) |
| CoreDNS | [v1.9.1](https://github.com/coredns/coredns/releases/tag/v1.9.1) | 
| Helm-controller | [v0.11.7](https://github.com/k3s-io/helm-controller/releases/tag/v0.11.7) |
| Local-path-provisioner | [v0.0.21](https://github.com/rancher/local-path-provisioner/releases/tag/v0.0.21) |

## Known Issues
- The etcd maintainers have recommended against the use of etcd 3.5.0-3.5.2 for new production workloads, due to a recently discovered bug that may cause data loss when etcd is killed under high load. [Please see this link for more details.](https://forums.rancher.com/t/rancher-kubernetes-distributions-and-etcd-3-5-updates/37485)

## Helpful Links
As always, we welcome and appreciate feedback from our community of users. Please feel free to:
- [Open issues here](https://github.com/rancher/k3s/issues/new/choose)
- [Join our Slack channel](https://slack.rancher.io/)
- [Check out our documentation](https://rancher.com/docs/k3s/latest/en/) for guidance on how to get started or to dive deep into K3s.
- [Read how you can contribute here](https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md)
