### PR TITLE
Minor: k3s update from v1.23.5+k3s1 to v1.23.6+k3s1

### DIFF
--- a/inventory/pi-cluster/group_vars/all.yml
+++ b/inventory/pi-cluster/group_vars/all.yml
@@ -4,7 +4,7 @@ ansible_user: charles
 k3s_state: installed # 'uninstalled' to uninstall k3s
 k3s_pods_cidr: 10.42.0.0/16
 k3s_github_url: https://github.com/k3s-io/k3s
-k3s_release_version: v1.23.5+k3s1
+k3s_release_version: v1.23.6+k3s1
 k3s_etcd_datastore: true
 k3s_become: true
 


### PR DESCRIPTION
<!-- v1.23.6+k3s1 -->
This release updates Kubernetes to v1.23.6, and fixes a number of issues.

For more details on what's new, see the [Kubernetes release notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.23.md#changelog-since-v1235).

## Changes since v1.23.5+k3s1:

* Fixed etcd URL in case of IPv6 address [(#5325)](https://github.com/k3s-io/k3s/pull/5325)
* The flannel configuration passed to `--flannel-conf` may now use the flannel backend type "wireguard". [(#5377)](https://github.com/k3s-io/k3s/pull/5377)
* netpol: Add dual-stack support [(#5387)](https://github.com/k3s-io/k3s/pull/5387)
* When using clusters with a mix of etcd-only/control-plane-only nodes, agents may now also join etcd-only servers [(#5367)](https://github.com/k3s-io/k3s/pull/5367)
* Fixed an issue that caused k3s to crash on startup when converting a node from agent to server. K3s will no longer panic on startup if the legacy node password file exists but does not contain any valid password entries. [(#5392)](https://github.com/k3s-io/k3s/pull/5392)
* K3s will no longer crash on startup if the scheduled cron expression triggered a snapshot before the internal controllers are fully initialized. [(#5383)](https://github.com/k3s-io/k3s/pull/5383)
* Add wireguard native flannel backend [(#5391)](https://github.com/k3s-io/k3s/pull/5391)
* Managed etcd controllers no longer run on clusters not using managed etcd. [(#5388)](https://github.com/k3s-io/k3s/pull/5388)
* Update helm-controller version [(#5398)](https://github.com/k3s-io/k3s/pull/5398)
* Add certificate rotation integration tests [(#5393)](https://github.com/k3s-io/k3s/pull/5393)
* fix: non-idiomatic returning of boolean expression [(#5343)](https://github.com/k3s-io/k3s/pull/5343)
* update trivy to 0.25.3 [(#5401)](https://github.com/k3s-io/k3s/pull/5401)
* Fixed flannel backend helper text [(#5422)](https://github.com/k3s-io/k3s/pull/5422)
* fix typo in Dockerfile [(#5370)](https://github.com/k3s-io/k3s/pull/5370)
* golang-ci has been upgraded to 1.45.2 [(#5403)](https://github.com/k3s-io/k3s/pull/5403)
* Added default endpoint for IPv6 [(#5420)](https://github.com/k3s-io/k3s/pull/5420)
* Bump Reencryption Test timeout, improve comments [(#5431)](https://github.com/k3s-io/k3s/pull/5431)
* update sonobuoy to 0.56.4 [(#5419)](https://github.com/k3s-io/k3s/pull/5419)
* Added support for repeated extra arguments [(#5373)](https://github.com/k3s-io/k3s/pull/5373)
* E2E: Added option to config hardened k3s [(#5415)](https://github.com/k3s-io/k3s/pull/5415)
* The embedded containerd version has been bumped to v1.5.11-k3s1 [(#5432)](https://github.com/k3s-io/k3s/pull/5432)
* Fix issue with RKE2 server hanging on startup when listing apiserver addresses [(#5437)](https://github.com/k3s-io/k3s/pull/5437)
* The embedded etcd version has been bumped to v3.5.3-k3s1 [(#5429)](https://github.com/k3s-io/k3s/pull/5429)
* Add s390x arch support for k3s [(#5018)](https://github.com/k3s-io/k3s/pull/5018)
* E2E Validation Improvements [(#5444)](https://github.com/k3s-io/k3s/pull/5444)
* Fix wrong default ipv6 cidr [(#5467)](https://github.com/k3s-io/k3s/pull/5467)
* Update Kubernetes to v1.23.6 [(#5477)](https://github.com/k3s-io/k3s/pull/5477)
* Fix issue with long-running apiserver endpoints watch [(#5478)](https://github.com/k3s-io/k3s/pull/5478)
* Secrets Encryption: Add RetryOnConflict around updating nodes [(#5495)](https://github.com/k3s-io/k3s/pull/5495)
* Bump containerd for selinux fix [(#5507)](https://github.com/k3s-io/k3s/pull/5507)
* Fix issue with datastore corruption on cluster-reset [(#5515)](https://github.com/k3s-io/k3s/pull/5515)
    * The embedded etcd has been bumped to v3.5.4-k3s1
    * Etcd is now shut down cleanly when performing a --cluster-reset 

## Embedded Component Versions
| Component | Version |
|---|---|
| Kubernetes | [v1.23.6](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.23.md#v1236) |
| Kine | [v0.8.1](https://github.com/k3s-io/kine/releases/tag/v0.8.1) |
| SQLite | [3.36.0](https://sqlite.org/releaselog/3_36_0.html) |
| Etcd | [v3.5.4-k3s1](https://github.com/k3s-io/etcd/releases/tag/v3.5.4-k3s1) |
| Containerd | [v1.5.11-k3s2](https://github.com/k3s-io/containerd/releases/tag/v1.5.11-k3s2) |
| Runc | [v1.0.3](https://github.com/opencontainers/runc/releases/tag/v1.0.3) |
| Flannel | [v0.17.0](https://github.com/flannel-io/flannel/releases/tag/v0.17.0) | 
| Metrics-server | [v0.5.2](https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.5.2) |
| Traefik | [v2.6.2](https://github.com/traefik/traefik/releases/tag/v2.6.2) |
| CoreDNS | [v1.9.1](https://github.com/coredns/coredns/releases/tag/v1.9.1) | 
| Helm-controller | [v0.12.1](https://github.com/k3s-io/helm-controller/releases/tag/v0.12.1) |
| Local-path-provisioner | [v0.0.21](https://github.com/rancher/local-path-provisioner/releases/tag/v0.0.21) |

## Helpful Links
As always, we welcome and appreciate feedback from our community of users. Please feel free to:
- [Open issues here](https://github.com/rancher/k3s/issues/new/choose)
- [Join our Slack channel](https://slack.rancher.io/)
- [Check out our documentation](https://rancher.com/docs/k3s/latest/en/) for guidance on how to get started or to dive deep into K3s.
- [Read how you can contribute here](https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md)
