### PR TITLE
Minor: k3s update from v1.23.6+k3s1 to v1.24.1+k3s1

### DIFF
--- a/inventory/pi-cluster/group_vars/all.yml
+++ b/inventory/pi-cluster/group_vars/all.yml
@@ -4,7 +4,7 @@ ansible_user: charles
 k3s_state: installed # 'uninstalled' to uninstall k3s
 k3s_pods_cidr: 10.42.0.0/16
 k3s_github_url: https://github.com/k3s-io/k3s
-k3s_release_version: v1.23.6+k3s1
+k3s_release_version: v1.24.1+k3s1
 k3s_etcd_datastore: true
 k3s_become: true
 


### PR DESCRIPTION
<!-- v1.24.1+k3s1 -->
This release updates Kubernetes to v1.24.1, and fixes a number of issues.

For more details on what's new, see the [Kubernetes release notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.24.md#changelog-since-v1240).

## Changes since v1.24.0+k3s1:

* Objects will be removed from Kubernetes when they are removed from manifest files. [(#5560)](https://github.com/k3s-io/k3s/pull/5560)
* Remove errant unversioned etcd go.mod entry [(#5548)](https://github.com/k3s-io/k3s/pull/5548)
* Pass the node-ip values to kubelet [(#5579)](https://github.com/k3s-io/k3s/pull/5579)
* The integrated apiserver network proxy's operational mode can now be set with `--egress-selector-mode`. [(#5577)](https://github.com/k3s-io/k3s/pull/5577)
* remove dweomer from maintainers [(#5582)](https://github.com/k3s-io/k3s/pull/5582)
* Bump dynamiclistener to v0.3.3 [(#5554)](https://github.com/k3s-io/k3s/pull/5554)
* Update to v1.24.1-k3s1 [(#5616)](https://github.com/k3s-io/k3s/pull/5616)
* Re-add `--cloud-provider=external` kubelet arg [(#5628)](https://github.com/k3s-io/k3s/pull/5628)
* Revert "Give kubelet the node-ip value (#5579)" [(#5636)](https://github.com/k3s-io/k3s/pull/5636)

## Embedded Component Versions
| Component | Version |
|---|---|
| Kubernetes | [v1.24.1](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.24.md#v1241) |
| Kine | [v0.9.1](https://github.com/k3s-io/kine/releases/tag/v0.9.1) |
| SQLite | [3.36.0](https://sqlite.org/releaselog/3_36_0.html) |
| Etcd | [v3.5.3-k3s1](https://github.com/k3s-io/etcd/releases/tag/v3.5.3-k3s1) |
| Containerd | [v1.5.11-k3s2](https://github.com/k3s-io/containerd/releases/tag/v1.5.11-k3s2) |
| Runc | [v1.1.1](https://github.com/opencontainers/runc/releases/tag/v1.1.1) |
| Flannel | [v0.17.0](https://github.com/flannel-io/flannel/releases/tag/v0.17.0) | 
| Metrics-server | [v0.5.2](https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.5.2) |
| Traefik | [v2.6.2](https://github.com/traefik/traefik/releases/tag/v2.6.2) |
| CoreDNS | [v1.9.1](https://github.com/coredns/coredns/releases/tag/v1.9.1) | 
| Helm-controller | [v0.12.1](https://github.com/k3s-io/helm-controller/releases/tag/v0.12.1) |
| Local-path-provisioner | [v0.0.21](https://github.com/rancher/local-path-provisioner/releases/tag/v0.0.21) |

## Helpful Links
As always, we welcome and appreciate feedback from our community of users. Please feel free to:
- [Open issues here](https://github.com/rancher/k3s/issues/new/choose)
- [Join our Slack channel](https://slack.rancher.io/)
- [Check out our documentation](https://rancher.com/docs/k3s/latest/en/) for guidance on how to get started or to dive deep into K3s.
- [Read how you can contribute here](https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md)