### PR TITLE
Minor: k3s update from v1.24.1+k3s1 to v1.24.2+k3s1

### DIFF
--- a/inventory/pi-cluster/group_vars/all.yml
+++ b/inventory/pi-cluster/group_vars/all.yml
@@ -4,7 +4,7 @@ ansible_user: charles
 k3s_state: installed # 'uninstalled' to uninstall k3s
 k3s_pods_cidr: 10.42.0.0/16
 k3s_github_url: https://github.com/k3s-io/k3s
-k3s_release_version: v1.24.1+k3s1
+k3s_release_version: v1.24.2+k3s1
 k3s_etcd_datastore: true
 k3s_become: true
 


### PR DESCRIPTION
<!-- v1.24.2+k3s1 -->
This release updates Kubernetes to v1.24.2, and fixes a number of issues.

For more details on what's new, see the [Kubernetes release notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.24.md#changelog-since-v1241).

## Changes since v1.24.1+k3s1:

* Remove kube-ipvs0 interface when cleaning up [(#5644)](https://github.com/k3s-io/k3s/pull/5644)
* The `--flannel-wireguard-mode` switch was added to the k3s cli to confgure the wireguard tunnel mode with the wireguard native backend [(#5552)](https://github.com/k3s-io/k3s/pull/5552)
* Introduce the flannelcniconf flag to set the desired flannel cni configuration [(#5656)](https://github.com/k3s-io/k3s/pull/5656)
* Integration Test: Startup [(#5630)](https://github.com/k3s-io/k3s/pull/5630)
* E2E Improvements and groundwork for test-pad tool [(#5593)](https://github.com/k3s-io/k3s/pull/5593)
* Update SECURITY.md [(#5607)](https://github.com/k3s-io/k3s/pull/5607)
* Introduce --enable-pprof flag to optionally run pprof server [(#5527)](https://github.com/k3s-io/k3s/pull/5527)
* E2E: Dualstack test [(#5617)](https://github.com/k3s-io/k3s/pull/5617)
* Pods created by ServiceLB are now all placed in the `kube-system` namespace, instead of in the same namespace as the Service. This allows for [enforcing Pod Security Standards](https://kubernetes.io/docs/tasks/configure-pod-container/enforce-standards-namespace-labels/) in user namespaces without breaking ServiceLB. [(#5657)](https://github.com/k3s-io/k3s/pull/5657)
* E2E: testpad prep, add alternate scripts location [(#5692)](https://github.com/k3s-io/k3s/pull/5692)
* Add arm tests and upgrade tests [(#5526)](https://github.com/k3s-io/k3s/pull/5526)
* Delay service readiness until after startuphooks have finished [(#5649)](https://github.com/k3s-io/k3s/pull/5649)
* Disable urfave markdown/man docs generation [(#5566)](https://github.com/k3s-io/k3s/pull/5566)
* The embedded etcd snapshot controller will no longer fail to process snapshot files containing characters that are invalid for use in ConfigMap keys. [(#5702)](https://github.com/k3s-io/k3s/pull/5702)
* Environment variables prefixed with `CONTAINERD_` now take priority over other existing variables, when passed through to containerd. [(#5706)](https://github.com/k3s-io/k3s/pull/5706)
* The embedded etcd instance no longer accepts connections from other nodes while resetting or restoring. [(#5542)](https://github.com/k3s-io/k3s/pull/5542)
* Enable compatibility tests for k3s s390x [(#5658)](https://github.com/k3s-io/k3s/pull/5658)
* Containerd: Enable enable_unprivileged_ports and enable_unprivileged_… [(#5538)](https://github.com/k3s-io/k3s/pull/5538)
* The embedded Helm controller now properly updates Chart deployments when HelmChartConfig resources are updated or deleted. [(#5731)](https://github.com/k3s-io/k3s/pull/5731)
* Update to v1.24.2 [(#5749)](https://github.com/k3s-io/k3s/pull/5749)

## Embedded Component Versions
| Component | Version |
|---|---|
| Kubernetes | [v1.24.2](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.24.md#v1242) |
| Kine | [v0.9.1](https://github.com/k3s-io/kine/releases/tag/v0.9.1) |
| SQLite | [3.36.0](https://sqlite.org/releaselog/3_36_0.html) |
| Etcd | [v3.5.3-k3s1](https://github.com/k3s-io/etcd/releases/tag/v3.5.3-k3s1) |
| Containerd | [v1.5.13-k3s1](https://github.com/k3s-io/containerd/releases/tag/v1.5.13-k3s1) |
| Runc | [v1.1.2](https://github.com/opencontainers/runc/releases/tag/v1.1.2) |
| Flannel | [v0.18.1](https://github.com/flannel-io/flannel/releases/tag/v0.18.1) | 
| Metrics-server | [v0.5.2](https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.5.2) |
| Traefik | [v2.6.2](https://github.com/traefik/traefik/releases/tag/v2.6.2) |
| CoreDNS | [v1.9.1](https://github.com/coredns/coredns/releases/tag/v1.9.1) | 
| Helm-controller | [v0.12.3](https://github.com/k3s-io/helm-controller/releases/tag/v0.12.3) |
| Local-path-provisioner | [v0.0.21](https://github.com/rancher/local-path-provisioner/releases/tag/v0.0.21) |

## Helpful Links
As always, we welcome and appreciate feedback from our community of users. Please feel free to:
- [Open issues here](https://github.com/rancher/k3s/issues/new/choose)
- [Join our Slack channel](https://slack.rancher.io/)
- [Check out our documentation](https://rancher.com/docs/k3s/latest/en/) for guidance on how to get started or to dive deep into K3s.
- [Read how you can contribute here](https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md)