### PR TITLE
Minor: k3s update from v1.24.2+k3s1 to v1.24.3+k3s1

### DIFF
--- a/inventory/pi-cluster/group_vars/all.yml
+++ b/inventory/pi-cluster/group_vars/all.yml
@@ -4,7 +4,7 @@ ansible_user: charles
 k3s_state: installed # 'uninstalled' to uninstall k3s
 k3s_pods_cidr: 10.42.0.0/16
 k3s_github_url: https://github.com/k3s-io/k3s
-k3s_release_version: v1.24.2+k3s1
+k3s_release_version: v1.24.3+k3s1
 k3s_etcd_datastore: true
 k3s_become: true
 


### PR DESCRIPTION
<!-- v1.24.3+k3s1 -->
This release updates Kubernetes to v1.24.3, and fixes a number of issues.

For more details on what's new, see the [Kubernetes release notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.24.md#changelog-since-v1242).

## Changes since v1.24.2+k3s2:
* Updated rancher/remotedialer to address a potential memory leak. [(#5784)](https://github.com/k3s-io/k3s/pull/5784)
* The embedded runc binary has been bumped to v1.1.3 [(#5783)](https://github.com/k3s-io/k3s/pull/5783)
* Fixed a regression that caused some containerd labels to be empty in cadvisor pod metrics [(#5812)](https://github.com/k3s-io/k3s/pull/5812)
* Replace dapper testing with regular docker [(#5805)](https://github.com/k3s-io/k3s/pull/5805)
* Promote v1.23.8+k3s2 to stable [(#5814)](https://github.com/k3s-io/k3s/pull/5814)
* Fixed an issue that would cause etcd restore to fail when restoring a snapshot made with secrets encryption enabled if the --secrets-encryption command was not included in the config file or restore command. [(#5817)](https://github.com/k3s-io/k3s/pull/5817)
* Fix deletion of svclb DaemonSet when Service is deleted
* Fixed a regression that caused ServiceLB DaemonSets to remain present after their corresponding Services were deleted.
    Manual cleanup of orphaned `svclb-*` DaemonSets from the `kube-system` namespace may be necessary if any LoadBalancer Services were deleted while running an affected release. [(#5824)](https://github.com/k3s-io/k3s/pull/5824)
* Address issues with etcd snapshots
* Scheduled etcd snapshots are now compressed when snapshot compression is enabled.
* The default etcd snapshot timeout has been raised to 5 minutes.
    Only one scheduled etcd snapshot will run at a time. If another snapshot would occur while the previous snapshot is still in progress, an error will be logged and the second scheduled snapshot will be skipped.
* S3 objects for etcd snapshots are now labeled with the correct content-type when compression is not enabled. [(#5833)](https://github.com/k3s-io/k3s/pull/5833)
* Update to v1.24.3 [(#5870)](https://github.com/k3s-io/k3s/pull/5870)

## Embedded Component Versions
| Component | Version |
|---|---|
| Kubernetes | [v1.24.3](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.24.md#v1243) |
| Kine | [v0.9.3](https://github.com/k3s-io/kine/releases/tag/v0.9.3) |
| SQLite | [3.36.0](https://sqlite.org/releaselog/3_36_0.html) |
| Etcd | [v3.5.3-k3s1](https://github.com/k3s-io/etcd/releases/tag/v3.5.3-k3s1) |
| Containerd | [v1.5.13-k3s1](https://github.com/k3s-io/containerd/releases/tag/v1.5.13-k3s1) |
| Runc | [v1.1.3](https://github.com/opencontainers/runc/releases/tag/v1.1.3) |
| Flannel | [v0.18.1](https://github.com/flannel-io/flannel/releases/tag/v0.18.1) |
| Metrics-server | [v0.5.2](https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.5.2) |
| Traefik | [v2.6.2](https://github.com/traefik/traefik/releases/tag/v2.6.2) |
| CoreDNS | [v1.9.1](https://github.com/coredns/coredns/releases/tag/v1.9.1) |
| Helm-controller | [v0.12.3](https://github.com/k3s-io/helm-controller/releases/tag/v0.12.3) |
| Local-path-provisioner | [v0.0.21](https://github.com/rancher/local-path-provisioner/releases/tag/v0.0.21) |

## Helpful Links
As always, we welcome and appreciate feedback from our community of users. Please feel free to:
- [Open issues here](https://github.com/rancher/k3s/issues/new/choose)
- [Join our Slack channel](https://slack.rancher.io/)
- [Check out our documentation](https://rancher.com/docs/k3s/latest/en/) for guidance on how to get started or to dive deep into K3s.
- [Read how you can contribute here](https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md)
