### PR TITLE
Minor: k3s update from v1.24.3+k3s1 to v1.24.4+k3s1

### DIFF
--- a/inventory/pi-cluster/group_vars/all.yml
+++ b/inventory/pi-cluster/group_vars/all.yml
@@ -4,7 +4,7 @@ ansible_user: charles
 k3s_state: installed # 'uninstalled' to uninstall k3s
 k3s_pods_cidr: 10.42.0.0/16
 k3s_github_url: https://github.com/k3s-io/k3s
-k3s_release_version: v1.24.3+k3s1
+k3s_release_version: v1.24.4+k3s1
 k3s_etcd_datastore: true
 k3s_become: true
 


### PR DESCRIPTION
<!-- v1.24.4+k3s1 -->
This release updates Kubernetes to v1.24.4, and fixes a number of issues.

This release restores use of the `--docker` flag to the v1.24 branch. See [docs/adrs/cri-dockerd.md](https://github.com/k3s-io/k3s/blob/master/docs/adrs/cri-dockerd.md) for more information.

For more details on what's new, see the [Kubernetes release notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.24.md#changelog-since-v1243).

## Changes since v1.24.3+k3s1:

* Put the terraform tests into their own packages and cleanup the test runs [(#5861)](https://github.com/k3s-io/k3s/pull/5861)
* Bumped rootlesskit to v1.0.1 [(#5773)](https://github.com/k3s-io/k3s/pull/5773)
* The initial health-check time for the etcd datastore has been raised from 10 to 30 seconds. [(#5882)](https://github.com/k3s-io/k3s/pull/5882)
* Fixed a regression that caused systemd cgroup driver autoconfiguration to fail on server nodes. [(#5851)](https://github.com/k3s-io/k3s/pull/5851)
* The embedded network policy controller has been updated to kube-router v1.5.0 [(#5789)](https://github.com/k3s-io/k3s/pull/5789)
* The configured service CIDR is now passed to the Kubernetes controller-manager via the `--service-cluster-ip-range` flag. Previously this value was only passed to the apiserver. [(#5894)](https://github.com/k3s-io/k3s/pull/5894)
* Updated dynamiclistener to fix a regression that prevented certificate renewal from working properly. [(#5896)](https://github.com/k3s-io/k3s/pull/5896)
* Promote v1.24.3+k3s1 to stable [(#5889)](https://github.com/k3s-io/k3s/pull/5889)
* ADR: Depreciating and Removing Old Flags [(#5890)](https://github.com/k3s-io/k3s/pull/5890)
* K3s no longer sets containerd's `enable_unprivileged_icmp` and `enable_unprivileged_ports` options on kernels that do not support them. [(#5913)](https://github.com/k3s-io/k3s/pull/5913)
* The etcd error on incorrect peer urls now correctly includes the expected https and 2380 port. [(#5909)](https://github.com/k3s-io/k3s/pull/5909)
* When set, the agent-token value is now written to `$datadir/server/agent-token`, in the same manner as the default (server) token is written to `$datadir/server/token` [(#5906)](https://github.com/k3s-io/k3s/pull/5906)
* Deprecated flags now warn of their v1.25 removal [(#5937)](https://github.com/k3s-io/k3s/pull/5937)
* Fix secrets reencryption for clusters with 8K+ secrets [(#5936)](https://github.com/k3s-io/k3s/pull/5936)
* Bumped minio-go to v7.0.33. This adds support for IMDSv2 credentials. [(#5928)](https://github.com/k3s-io/k3s/pull/5928)
* Upgrade GH Actions macos-10.15 to macos-12 [(#5953)](https://github.com/k3s-io/k3s/pull/5953)
* Added dualstack IP auto detection [(#5920)](https://github.com/k3s-io/k3s/pull/5920)
* The `--docker` flag has been restored to k3s, as a shortcut to enabling embedded cri-dockerd [(#5916)](https://github.com/k3s-io/k3s/pull/5916)
* Update MAINTAINERS with new folks and departures [(#5948)](https://github.com/k3s-io/k3s/pull/5948)
* Removing checkbox indicating backports [(#5947)](https://github.com/k3s-io/k3s/pull/5947)
* fix checkError in terraform/testutils [(#5893)](https://github.com/k3s-io/k3s/pull/5893)
* Add scripts to run e2e test using ansible [(#5134)](https://github.com/k3s-io/k3s/pull/5134)
* Updated flannel to v0.19.1 [(#5962)](https://github.com/k3s-io/k3s/pull/5962)
* Update run scripts [(#5979)](https://github.com/k3s-io/k3s/pull/5979)
* Convert install/cgroup tests to yaml based config [(#5992)](https://github.com/k3s-io/k3s/pull/5992)
* E2E: Local cluster testing [(#5977)](https://github.com/k3s-io/k3s/pull/5977)
* Add nightly install github action [(#5998)](https://github.com/k3s-io/k3s/pull/5998)
* Convert codespell from Drone to GH actions [(#6004)](https://github.com/k3s-io/k3s/pull/6004)
* Update to v1.24.4 [(#6014)](https://github.com/k3s-io/k3s/pull/6014)

## Embedded Component Versions
| Component | Version |
|---|---|
| Kubernetes | [v1.24.4](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.24.md#v1244) |
| Kine | [v0.9.3](https://github.com/k3s-io/kine/releases/tag/v0.9.3) |
| SQLite | [3.36.0](https://sqlite.org/releaselog/3_36_0.html) |
| Etcd | [v3.5.3-k3s1](https://github.com/k3s-io/etcd/releases/tag/v3.5.3-k3s1) |
| Containerd | [v1.5.13-k3s1](https://github.com/k3s-io/containerd/releases/tag/v1.5.13-k3s1) |
| Runc | [v1.1.3](https://github.com/opencontainers/runc/releases/tag/v1.1.3) |
| Flannel | [v0.19.1](https://github.com/flannel-io/flannel/releases/tag/v0.19.1) | 
| Metrics-server | [v0.5.2](https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.5.2) |
| Traefik | [v2.6.2](https://github.com/traefik/traefik/releases/tag/v2.6.2) |
| CoreDNS | [v1.9.1](https://github.com/coredns/coredns/releases/tag/v1.9.1) | 
| Helm-controller | [v0.12.3](https://github.com/k3s-io/helm-controller/releases/tag/v0.12.3) |
| Local-path-provisioner | [v0.0.21](https://github.com/rancher/local-path-provisioner/releases/tag/v0.0.21) |

## Helpful Links
As always, we welcome and appreciate feedback from our community of users. Please feel free to:
- [Open issues here](https://github.com/rancher/k3s/issues/new/choose)
- [Join our Slack channel](https://slack.rancher.io/)
- [Check out our documentation](https://rancher.com/docs/k3s/latest/en/) for guidance on how to get started or to dive deep into K3s.
- [Read how you can contribute here](https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md)