### PR TITLE
Minor: k3s update from v1.24.4+k3s1 to v1.25.0+k3s1

### DIFF
--- a/inventory/pi-cluster/group_vars/all.yml
+++ b/inventory/pi-cluster/group_vars/all.yml
@@ -4,7 +4,7 @@ ansible_user: charles
 k3s_state: installed # 'uninstalled' to uninstall k3s
 k3s_pods_cidr: 10.42.0.0/16
 k3s_github_url: https://github.com/k3s-io/k3s
-k3s_release_version: v1.24.4+k3s1
+k3s_release_version: v1.25.0+k3s1
 k3s_etcd_datastore: true
 k3s_become: true
 


### PR DESCRIPTION
<!-- v1.25.0+k3s1 -->
This release is K3S's first in the v1.25 line. This release updates Kubernetes to v1.25.0.

Before upgrading from earlier releases, be sure to read the Kubernetes [Urgent Upgrade Notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.25.md#urgent-upgrade-notes).

**Important Note:** Kubernetes v1.25 removes the beta `PodSecurityPolicy` admission plugin. Please follow the [upstream documentation](https://kubernetes.io/docs/tasks/configure-pod-container/migrate-from-psp/) to migrate from PSP if using the built-in PodSecurity Admission Plugin, prior to upgrading to v1.25.0+k3s1.

## Changes since v1.24.4+k3s1:

* Update Kubernetes to v1.25.0 [(#6040)](https://github.com/k3s-io/k3s/pull/6040)
* Remove `--containerd` flag from windows kubelet args [(#6028)](https://github.com/k3s-io/k3s/pull/6028)
* E2E: Add support for CentOS 7 and Rocky 8 [(#6015)](https://github.com/k3s-io/k3s/pull/6015)
* Convert install tests to run PR build of k3s [(#6003)](https://github.com/k3s-io/k3s/pull/6003)
* CI: update Fedora 34 -> 35 [(#5996)](https://github.com/k3s-io/k3s/pull/5996)
* Fix dualStack test and change ipv6 network prefix [(#6023)](https://github.com/k3s-io/k3s/pull/6023)
* Fix e2e tests [(#6018)](https://github.com/k3s-io/k3s/pull/6018)
* Update README.md [(#6048)](https://github.com/k3s-io/k3s/pull/6048)
* Remove wireguard interfaces when deleting the cluster [(#6055)](https://github.com/k3s-io/k3s/pull/6055)
* Add validation check to confirm correct golang version for Kubernetes [(#6050)](https://github.com/k3s-io/k3s/pull/6050)
* Expand startup integration test [(#6030)](https://github.com/k3s-io/k3s/pull/6030)
* Update go.mod version to 1.19 [(#6049)](https://github.com/k3s-io/k3s/pull/6049)
* Usage of `--cluster-secret`, `--no-deploy`, and `--no-flannel` is no longer supported. Attempts to use these flags will cause fatal errors. See [the docs](https://k3s-io.github.io/docs/docs/reference/server-config#deprecated-options) for their replacement. [(#6069)](https://github.com/k3s-io/k3s/pull/6069)
* Update Flannel version to fix older iptables version issue. [(#6090)](https://github.com/k3s-io/k3s/pull/6090)
* The bundled version of runc has been bumped to v1.1.4 [(#6071)](https://github.com/k3s-io/k3s/pull/6071)
* The embedded containerd version has been bumped to v1.6.8-k3s1 [(#6078)](https://github.com/k3s-io/k3s/pull/6078)
* Fix deprecation message [(#6112)](https://github.com/k3s-io/k3s/pull/6112)
* Added warning message for flannel backend additional options deprecation [(#6111)](https://github.com/k3s-io/k3s/pull/6111)

## Embedded Component Versions
| Component | Version |
|---|---|
| Kubernetes | [v1.25.0](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.25.md#v1250) |
| Kine | [v0.9.3](https://github.com/k3s-io/kine/releases/tag/v0.9.3) |
| SQLite | [3.36.0](https://sqlite.org/releaselog/3_36_0.html) |
| Etcd | [v3.5.3-k3s1](https://github.com/k3s-io/etcd/releases/tag/v3.5.3-k3s1) |
| Containerd | [v1.5.13-k3s2](https://github.com/k3s-io/containerd/releases/tag/v1.5.13-k3s2) |
| Runc | [v1.1.3](https://github.com/opencontainers/runc/releases/tag/v1.1.3) |
| Flannel | [v0.19.1](https://github.com/flannel-io/flannel/releases/tag/v0.19.1) | 
| Metrics-server | [v0.5.2](https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.5.2) |
| Traefik | [v2.6.2](https://github.com/traefik/traefik/releases/tag/v2.6.2) |
| CoreDNS | [v1.9.1](https://github.com/coredns/coredns/releases/tag/v1.9.1) | 
| Helm-controller | [v0.12.3](https://github.com/k3s-io/helm-controller/releases/tag/v0.12.3) |
| Local-path-provisioner | [v0.0.21](https://github.com/rancher/local-path-provisioner/releases/tag/v0.0.21) |

## Helpful Links
As always, we welcome and appreciate feedback from our community of users. Please feel free to:
- [Open issues here](https://github.com/rancher/k3s/issues/new/choose)
- [Join our Slack channel](https://slack.rancher.io/)
- [Check out our documentation](https://rancher.com/docs/k3s/latest/en/) for guidance on how to get started or to dive deep into K3s.
- [Read how you can contribute here](https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md)