### PR TITLE
Minor: k3s update from v1.25.2+k3s1 to v1.25.3+k3s1

### DIFF
--- a/inventory/pi-cluster/group_vars/all.yml
+++ b/inventory/pi-cluster/group_vars/all.yml
@@ -4,7 +4,7 @@ ansible_user: charles
 k3s_state: installed # 'uninstalled' to uninstall k3s
 k3s_pods_cidr: 10.42.0.0/16
 k3s_github_url: https://github.com/k3s-io/k3s
-k3s_release_version: v1.25.2+k3s1
+k3s_release_version: v1.25.3+k3s1
 k3s_etcd_datastore: true
 k3s_become: true
 


### PR DESCRIPTION
<!-- v1.25.3+k3s1 -->
This release updates Kubernetes to v1.25.3, and fixes a number of issues.

For more details on what's new, see the [Kubernetes release notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.25.md#changelog-since-v1252).

## Changes since v1.25.2+k3s1:

* E2E: Groundwork for PR runs [(#6131)](https://github.com/k3s-io/k3s/pull/6131)
* Fix flannel for deployments of nodes which do not belong to the same network and connect using their public IP [(#6180)](https://github.com/k3s-io/k3s/pull/6180)
* Mark v1.24.6+k3s1 as stable [(#6193)](https://github.com/k3s-io/k3s/pull/6193)
* Add cluster reset test [(#6161)](https://github.com/k3s-io/k3s/pull/6161)
* The embedded metrics-server version has been bumped to v0.6.1 [(#6151)](https://github.com/k3s-io/k3s/pull/6151)
* The ServiceLB (klipper-lb) service controller is now integrated into the K3s stub cloud controller manager. [(#6181)](https://github.com/k3s-io/k3s/pull/6181)
* Events recorded to the cluster by embedded controllers are now properly formatted in the service logs. [(#6203)](https://github.com/k3s-io/k3s/pull/6203)
* Fix `error dialing backend` errors in apiserver network proxy [(#6216)](https://github.com/k3s-io/k3s/pull/6216)
  * Fixed an issue with the apiserver network proxy that caused `kubectl exec` to occasionally fail with `error dialing backend: EOF`
  * Fixed an issue with the apiserver network proxy that caused `kubectl exec` and `kubectl logs` to fail when a custom kubelet port was used, and the custom port was blocked by firewall or security group rules.
* Fix the typo in the test [(#6183)](https://github.com/k3s-io/k3s/pull/6183)
* Use setup-go action to cache dependencies [(#6220)](https://github.com/k3s-io/k3s/pull/6220)
* Add journalctl logs to E2E tests [(#6224)](https://github.com/k3s-io/k3s/pull/6224)
* The embedded Traefik version has been bumped to v2.9.1 / chart 12.0.0 [(#6223)](https://github.com/k3s-io/k3s/pull/6223)
* Fix flakey etcd test [(#6232)](https://github.com/k3s-io/k3s/pull/6232)
* Replace deprecated ioutil package [(#6230)](https://github.com/k3s-io/k3s/pull/6230)
* Fix dualStack test [(#6245)](https://github.com/k3s-io/k3s/pull/6245)
* Add ServiceAccount for svclb pods [(#6253)](https://github.com/k3s-io/k3s/pull/6253)
* Update to v1.25.3-k3s1 [(#6269)](https://github.com/k3s-io/k3s/pull/6269)
* Return ProviderID in URI format [(#6284)](https://github.com/k3s-io/k3s/pull/6284)
* Corrected CCM RBAC to allow for removal of legacy service finalizer during upgrades. [(#6306)](https://github.com/k3s-io/k3s/pull/6306)
* Added a new --flannel-external-ip flag. [(#6321)](https://github.com/k3s-io/k3s/pull/6321)
  * When enabled, Flannel traffic will now use the nodes external IPs, instead of internal.
  * This is meant for use with distributed clusters that are not all on the same local network.

## Embedded Component Versions
| Component | Version |
|---|---|
| Kubernetes | [v1.25.3](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.25.md#v1253) |
| Kine | [v0.9.3](https://github.com/k3s-io/kine/releases/tag/v0.9.3) |
| SQLite | [3.36.0](https://sqlite.org/releaselog/3_36_0.html) |
| Etcd | [v3.5.3-k3s1](https://github.com/k3s-io/etcd/releases/tag/v3.5.3-k3s1) |
| Containerd | [v1.6.8-k3s1](https://github.com/k3s-io/containerd/releases/tag/v1.6.8-k3s1) |
| Runc | [v1.1.4](https://github.com/opencontainers/runc/releases/tag/v1.1.4) |
| Flannel | [v0.19.2](https://github.com/flannel-io/flannel/releases/tag/v0.19.2) |
| Metrics-server | [v0.6.1](https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.6.1) |
| Traefik | [v2.9.1](https://github.com/traefik/traefik/releases/tag/v2.9.1) |
| CoreDNS | [v1.9.1](https://github.com/coredns/coredns/releases/tag/v1.9.1) |
| Helm-controller | [v0.12.3](https://github.com/k3s-io/helm-controller/releases/tag/v0.12.3) |
| Local-path-provisioner | [v0.0.21](https://github.com/rancher/local-path-provisioner/releases/tag/v0.0.21) |

## Helpful Links
As always, we welcome and appreciate feedback from our community of users. Please feel free to:
- [Open issues here](https://github.com/rancher/k3s/issues/new/choose)
- [Join our Slack channel](https://slack.rancher.io/)
- [Check out our documentation](https://rancher.com/docs/k3s/latest/en/) for guidance on how to get started or to dive deep into K3s.
- [Read how you can contribute here](https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md)