### PR TITLE
Minor: k3s update from v1.25.4+k3s1 to v1.26.0+k3s1

### DIFF
--- a/inventory/pi-cluster/group_vars/all.yml
+++ b/inventory/pi-cluster/group_vars/all.yml
@@ -4,7 +4,7 @@ ansible_user: charles
 k3s_state: installed # 'uninstalled' to uninstall k3s
 k3s_pods_cidr: 10.42.0.0/16
 k3s_github_url: https://github.com/k3s-io/k3s
-k3s_release_version: v1.25.4+k3s1
+k3s_release_version: v1.26.0+k3s1
 k3s_etcd_datastore: true
 k3s_become: true
 


### PR DESCRIPTION
<!-- v1.26.0+k3s1 -->
This release is K3S's first in the v1.26 line. This release updates Kubernetes to v1.26.0.

Before upgrading from earlier releases, be sure to read the Kubernetes [Urgent Upgrade Notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.26.md#urgent-upgrade-notes).

## Changes since v1.25.5+k3s1:

* Remove deprecated flags in v1.26 [(#6574)](https://github.com/k3s-io/k3s/pull/6574)
* Using "etcd-snapshot" for saving snapshots is now deprecated, use "etcd-snapshot save" instead. [(#6575)](https://github.com/k3s-io/k3s/pull/6575)
* Update to v1.26.0-k3s1
 * * Update kubernetes to v1.26.0-k3s1
 * * Update cri-tools to  v1.26.0-rc.0-k3s1
 * * Update helm controller to v0.13.1
 * * Update etcd to v3.5.5-k3s1
 * * Update cri-dockerd to the latest 1.26.0
 * * Update cadvisor
 * * Update containerd to v1.6.12-k3s1 [(#6370)](https://github.com/k3s-io/k3s/pull/6370)
* Preload iptable_filter/ip6table_filter [(#6645)](https://github.com/k3s-io/k3s/pull/6645)
* Bump k3s-root version to v0.12.1 [(#6651)](https://github.com/k3s-io/k3s/pull/6651)

## Embedded Component Versions
| Component | Version |
|---|---|
| Kubernetes | [v1.26.0](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.26.md#v1260) |
| Kine | [v0.9.8](https://github.com/k3s-io/kine/releases/tag/v0.9.8) |
| SQLite | [3.39.2](https://sqlite.org/releaselog/3_39_2.html) |
| Etcd | [v3.5.5-k3s1](https://github.com/k3s-io/etcd/releases/tag/v3.5.5-k3s1) |
| Containerd | [v1.6.12-k3s1](https://github.com/k3s-io/containerd/releases/tag/v1.6.12-k3s1) |
| Runc | [v1.1.4](https://github.com/opencontainers/runc/releases/tag/v1.1.4) |
| Flannel | [v0.20.2](https://github.com/flannel-io/flannel/releases/tag/v0.20.2) | 
| Metrics-server | [v0.6.2](https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.6.2) |
| Traefik | [v2.9.4](https://github.com/traefik/traefik/releases/tag/v2.9.4) |
| CoreDNS | [v1.9.4](https://github.com/coredns/coredns/releases/tag/v1.9.4) | 
| Helm-controller | [v0.13.1](https://github.com/k3s-io/helm-controller/releases/tag/v0.13.1) |
| Local-path-provisioner | [v0.0.23](https://github.com/rancher/local-path-provisioner/releases/tag/v0.0.23) |

## Helpful Links
As always, we welcome and appreciate feedback from our community of users. Please feel free to:
- [Open issues here](https://github.com/rancher/k3s/issues/new/choose)
- [Join our Slack channel](https://slack.rancher.io/)
- [Check out our documentation](https://rancher.com/docs/k3s/latest/en/) for guidance on how to get started or to dive deep into K3s.
- [Read how you can contribute here](https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md)