### PR TITLE
Minor: k3s update from v1.26.0+k3s1 to v1.26.1+k3s1

### DIFF
--- a/inventory/pi-cluster/group_vars/all.yml
+++ b/inventory/pi-cluster/group_vars/all.yml
@@ -4,7 +4,7 @@ ansible_user: charles
 k3s_state: installed # 'uninstalled' to uninstall k3s
 k3s_pods_cidr: 10.42.0.0/16
 k3s_github_url: https://github.com/k3s-io/k3s
-k3s_release_version: v1.26.0+k3s1
+k3s_release_version: v1.26.1+k3s1
 k3s_etcd_datastore: true
 k3s_become: true
 


### PR DESCRIPTION
<!-- v1.26.1+k3s1 -->
This release updates Kubernetes to v1.26.1, and fixes a number of issues.

For more details on what's new, see the [Kubernetes release notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.26.md#changelog-since-v1260).

## Changes since v1.26.0+k3s2:

* Add jitter to scheduled snapshots and retry harder on conflicts [(#6715)](https://github.com/k3s-io/k3s/pull/6715)
  * Scheduled etcd snapshots are now offset by a short random delay of up to several seconds. This should prevent multi-server clusters from executing pathological behavior when attempting to simultaneously update the snapshot list ConfigMap. The snapshot controller will also be more persistent in attempting to update the snapshot list.
* Adjust e2e test run script and fixes [(#6718)](https://github.com/k3s-io/k3s/pull/6718)
* RIP Codespell [(#6701)](https://github.com/k3s-io/k3s/pull/6701)
* Bump alpine from 3.16 to 3.17 in /package [(#6688)](https://github.com/k3s-io/k3s/pull/6688)
* Bump alpine from 3.16 to 3.17 in /conformance [(#6687)](https://github.com/k3s-io/k3s/pull/6687)
* Bump containerd to v1.6.15-k3s1 [(#6722)](https://github.com/k3s-io/k3s/pull/6722)
  * The embedded containerd version has been bumped to v1.6.15-k3s1
* Containerd restart testlet [(#6696)](https://github.com/k3s-io/k3s/pull/6696)
* Bump ubuntu from 20.04 to 22.04 in /tests/e2e/scripts [(#6686)](https://github.com/k3s-io/k3s/pull/6686)
* Add explicit read permissions to workflows [(#6700)](https://github.com/k3s-io/k3s/pull/6700)
* Pass through default tls-cipher-suites [(#6725)](https://github.com/k3s-io/k3s/pull/6725)
  * The K3s default cipher suites are now explicitly passed in to kube-apiserver, ensuring that all listeners use these values.
* Bump golang:alpine image version [(#6683)](https://github.com/k3s-io/k3s/pull/6683)
* Bugfix: do not break cert-manager when pprof is enabled [(#6635)](https://github.com/k3s-io/k3s/pull/6635)
* Fix CI tests on Alpine 3.17 [(#6744)](https://github.com/k3s-io/k3s/pull/6744)
* Update Stable to 1.25.5+k3s2 [(#6753)](https://github.com/k3s-io/k3s/pull/6753)
* Bump action/download-artifact to v3 [(#6746)](https://github.com/k3s-io/k3s/pull/6746)
* Generate report and upload test results [(#6737)](https://github.com/k3s-io/k3s/pull/6737)
* Slow dependency CI to weekly [(#6764)](https://github.com/k3s-io/k3s/pull/6764)
* Fix Drone plugins/docker tag for 32 bit arm [(#6769)](https://github.com/k3s-io/k3s/pull/6769)
* Update to v1.26.1-k3s1 [(#6774)](https://github.com/k3s-io/k3s/pull/6774)

## Embedded Component Versions
| Component | Version |
|---|---|
| Kubernetes | [v1.26.1](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.26.md#v1261) |
| Kine | [v0.9.8](https://github.com/k3s-io/kine/releases/tag/v0.9.8) |
| SQLite | [3.39.2](https://sqlite.org/releaselog/3_39_2.html) |
| Etcd | [v3.5.5-k3s1](https://github.com/k3s-io/etcd/releases/tag/v3.5.5-k3s1) |
| Containerd | [v1.6.15-k3s1](https://github.com/k3s-io/containerd/releases/tag/v1.6.15-k3s1) |
| Runc | [v1.1.4](https://github.com/opencontainers/runc/releases/tag/v1.1.4) |
| Flannel | [v0.20.2](https://github.com/flannel-io/flannel/releases/tag/v0.20.2) | 
| Metrics-server | [v0.6.2](https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.6.2) |
| Traefik | [v2.9.4](https://github.com/traefik/traefik/releases/tag/v2.9.4) |
| CoreDNS | [v1.9.4](https://github.com/coredns/coredns/releases/tag/v1.9.4) | 
| Helm-controller | [v0.13.1](https://github.com/k3s-io/helm-controller/releases/tag/v0.13.1) |
| Local-path-provisioner | [v0.0.23](https://github.com/rancher/local-path-provisioner/releases/tag/v0.0.23) |

## Helpful Links
As always, we welcome and appreciate feedback from our community of users. Please feel free to:
- [Open issues here](https://github.com/rancher/k3s/issues/new/choose)
- [Join our Slack channel](https://slack.rancher.io/)
- [Check out our documentation](https://rancher.com/docs/k3s/latest/en/) for guidance on how to get started or to dive deep into K3s.
- [Read how you can contribute here](https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md)