### PR TITLE
Minor: k3s update from v1.26.1+k3s1 to v1.26.2+k3s1

### DIFF
--- a/inventory/pi-cluster/group_vars/all.yml
+++ b/inventory/pi-cluster/group_vars/all.yml
@@ -4,7 +4,7 @@ ansible_user: charles
 k3s_state: installed # 'uninstalled' to uninstall k3s
 k3s_pods_cidr: 10.42.0.0/16
 k3s_github_url: https://github.com/k3s-io/k3s
-k3s_release_version: v1.26.1+k3s1
+k3s_release_version: v1.26.2+k3s1
 k3s_etcd_datastore: true
 k3s_become: true
 


### PR DESCRIPTION
<!-- v1.26.2+k3s1 -->
This release updates Kubernetes to v1.26.2, and fixes a number of issues.

For more details on what's new, see the [Kubernetes release notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.26.md#changelog-since-v1261).

## Changes since v1.26.1+k3s1:

* Add build tag to disable cri-dockerd [(#6760)](https://github.com/k3s-io/k3s/pull/6760)
* Bump cri-dockerd [(#6797)](https://github.com/k3s-io/k3s/pull/6797)
  * The embedded cri-dockerd has been updated to v0.3.1
* Update stable channel to v1.25.6+k3s1 [(#6828)](https://github.com/k3s-io/k3s/pull/6828)
* E2E Rancher and Hardened script improvements [(#6778)](https://github.com/k3s-io/k3s/pull/6778)
* Add Ayedo to Adopters [(#6801)](https://github.com/k3s-io/k3s/pull/6801)
* Consolidate E2E tests and GH Actions [(#6772)](https://github.com/k3s-io/k3s/pull/6772)
* Allow ServiceLB to honor `ExternalTrafficPolicy=Local` [(#6726)](https://github.com/k3s-io/k3s/pull/6726)
  * ServiceLB now honors the Service's ExternalTrafficPolicy. When set to Local, the LoadBalancer will only advertise addresses of Nodes with a Pod for the Service, and will not forward traffic to other cluster members.
* Fix cronjob example [(#6707)](https://github.com/k3s-io/k3s/pull/6707)
* Bump vagrant boxes to fedora37 [(#6832)](https://github.com/k3s-io/k3s/pull/6832)
* Ensure flag type consistency [(#6852)](https://github.com/k3s-io/k3s/pull/6852)
* E2E: Consoldiate docker and prefer bundled tests into new startup test [(#6851)](https://github.com/k3s-io/k3s/pull/6851)
* Fix reference to documentation [(#6860)](https://github.com/k3s-io/k3s/pull/6860)
* Bump deps: trivy, sonobuoy, dapper, golangci-lint, gopls [(#6807)](https://github.com/k3s-io/k3s/pull/6807)
* Fix check for (open)SUSE version [(#6791)](https://github.com/k3s-io/k3s/pull/6791)
* Add support for user-provided CA certificates [(#6615)](https://github.com/k3s-io/k3s/pull/6615)
  * K3s now functions properly when the cluster CA certificates are signed by an existing root or intermediate CA. You can find a sample script for generating such certificates before K3s starts in the github repo at [contrib/util/certs.sh](https://github.com/k3s-io/k3s/blob/master/contrib/util/certs.sh).
* Ignore value conflicts when reencrypting secrets [(#6850)](https://github.com/k3s-io/k3s/pull/6850)
* Add `kubeadm` style bootstrap token secret support [(#6663)](https://github.com/k3s-io/k3s/pull/6663)
  * K3s now supports `kubeadm` style join tokens. `k3s token create` now creates join token secrets, optionally with a limited TTL.
  * K3s agents joined with an expired or deleted token stay in the cluster using existing client certificates via the NodeAuthorization admission plugin, unless their Node object is deleted from the cluster.
* Add NATS to the list of supported data stores [(#6876)](https://github.com/k3s-io/k3s/pull/6876)
* Use default address family when adding kubernetes service address to SAN list [(#6857)](https://github.com/k3s-io/k3s/pull/6857)
  * The apiserver advertised address and IP SAN entry are now set correctly on clusters that use IPv6 as the default IP family.
* Fix issue with servicelb startup failure when validating webhooks block creation [(#6911)](https://github.com/k3s-io/k3s/pull/6911)
  * The embedded cloud controller manager will no longer attempt to unconditionally re-create its namespace and serviceaccount on startup. This resolves an issue that could cause a deadlocked cluster when fail-closed webhooks are in use.
* Fix access to hostNetwork port on NodeIP when egress-selector-mode=agent [(#6829)](https://github.com/k3s-io/k3s/pull/6829)
  * Fixed an issue that would cause the apiserver egress proxy to attempt to use the agent tunnel to connect to service endpoints even in agent or disabled mode.
* Wait for server to become ready before creating token [(#6932)](https://github.com/k3s-io/k3s/pull/6932)
* Allow for multiple sets of leader-elected controllers [(#6922)](https://github.com/k3s-io/k3s/pull/6922)
  * Fixed an issue where leader-elected controllers for managed etcd did not run on etcd-only nodes
* Update Flannel to v0.21.1 [(#6944)](https://github.com/k3s-io/k3s/pull/6944)
* Fix Nightly E2E tests [(#6950)](https://github.com/k3s-io/k3s/pull/6950)
* Fix etcd and ca-cert rotate issues [(#6952)](https://github.com/k3s-io/k3s/pull/6952)
* Fix ServiceLB dual-stack ingress IP listing [(#6979)](https://github.com/k3s-io/k3s/pull/6979)
  * Resolved an issue with ServiceLB that would cause it to advertise node IPv6 addresses, even if the cluster or service was not enabled for dual-stack operation.
* Bump kine to v0.9.9 [(#6974)](https://github.com/k3s-io/k3s/pull/6974)
  * The embedded kine version has been bumped to v0.9.9. Compaction log messages are now omitted at `info` level for increased visibility.
* Update to v1.26.2-k3s1 [(#7011)](https://github.com/k3s-io/k3s/pull/7011)

## Embedded Component Versions
| Component | Version |
|---|---|
| Kubernetes | [v1.26.2](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.26.md#v1262) |
| Kine | [v0.9.9](https://github.com/k3s-io/kine/releases/tag/v0.9.9) |
| SQLite | [3.39.2](https://sqlite.org/releaselog/3_39_2.html) |
| Etcd | [v3.5.5-k3s1](https://github.com/k3s-io/etcd/releases/tag/v3.5.5-k3s1) |
| Containerd | [v1.6.15-k3s1](https://github.com/k3s-io/containerd/releases/tag/v1.6.15-k3s1) |
| Runc | [v1.1.4](https://github.com/opencontainers/runc/releases/tag/v1.1.4) |
| Flannel | [v0.21.1](https://github.com/flannel-io/flannel/releases/tag/v0.21.1) | 
| Metrics-server | [v0.6.2](https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.6.2) |
| Traefik | [v2.9.4](https://github.com/traefik/traefik/releases/tag/v2.9.4) |
| CoreDNS | [v1.9.4](https://github.com/coredns/coredns/releases/tag/v1.9.4) | 
| Helm-controller | [v0.13.1](https://github.com/k3s-io/helm-controller/releases/tag/v0.13.1) |
| Local-path-provisioner | [v0.0.23](https://github.com/rancher/local-path-provisioner/releases/tag/v0.0.23) |

## Helpful Links
As always, we welcome and appreciate feedback from our community of users. Please feel free to:
- [Open issues here](https://github.com/rancher/k3s/issues/new/choose)
- [Join our Slack channel](https://slack.rancher.io/)
- [Check out our documentation](https://rancher.com/docs/k3s/latest/en/) for guidance on how to get started or to dive deep into K3s.
- [Read how you can contribute here](https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md)