### PR TITLE
Minor: k3s update from v1.27.3+k3s1 to v1.27.5+k3s1

### DIFF
--- a/inventory/pi-cluster/group_vars/all.yml
+++ b/inventory/pi-cluster/group_vars/all.yml
@@ -4,7 +4,7 @@ ansible_user: charles
 k3s_state: installed # 'uninstalled' to uninstall k3s
 k3s_pods_cidr: 10.42.0.0/16
 k3s_github_url: https://github.com/k3s-io/k3s
-k3s_release_version: v1.27.3+k3s1
+k3s_release_version: v1.27.5+k3s1
 k3s_etcd_datastore: true
 k3s_become: true
 


### PR DESCRIPTION
<!-- v1.27.5+k3s1 -->
This release updates Kubernetes to v1.27.5, and fixes a number of issues.

For more details on what's new, see the [Kubernetes release notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.27.md#changelog-since-v1274).

## Changes since v1.27.4+k3s1:

* Update cni plugins version to v1.3.0 [(#8056)](https://github.com/k3s-io/k3s/pull/8056)
  * Upgraded cni-plugins to v1.3.0
* Update flannel to v0.22.1 [(#8057)](https://github.com/k3s-io/k3s/pull/8057)
  * Update flannel to v0.22.1
* ADR on secrets encryption v3 [(#7938)](https://github.com/k3s-io/k3s/pull/7938)
* Unit test for MustFindString [(#8013)](https://github.com/k3s-io/k3s/pull/8013)
* Add support for using base template in etc/containerd/config.toml.tmpl [(#7991)](https://github.com/k3s-io/k3s/pull/7991)
  * User-provided containerd config templates may now use `{{ template "base" . }}` to include the default K3s template content. This makes it easier to maintain user configuration if the only need is to add additional sections to the file.
* Make apiserver egress args conditional on egress-selector-mode [(#7972)](https://github.com/k3s-io/k3s/pull/7972)
  * K3s no longer enables the apiserver's `enable-aggregator-routing` flag when the egress proxy is not being used to route connections to in-cluster endpoints.
* Security bump to `docker/distribution` [(#8047)](https://github.com/k3s-io/k3s/pull/8047)
* Fix coreos multiple installs [(#8083)](https://github.com/k3s-io/k3s/pull/8083)
* Update stable channel to v1.27.4+k3s1 [(#8067)](https://github.com/k3s-io/k3s/pull/8067)
* Fix tailscale bug with ip modes [(#8077)](https://github.com/k3s-io/k3s/pull/8077)
* Consolidate CopyFile functions [(#8079)](https://github.com/k3s-io/k3s/pull/8079)
* E2E: Support GOCOVER for more tests + fixes [(#8080)](https://github.com/k3s-io/k3s/pull/8080)
* Fix typo in terraform/README.md [(#8090)](https://github.com/k3s-io/k3s/pull/8090)
* Add FilterCN function to prevent SAN Stuffing [(#8085)](https://github.com/k3s-io/k3s/pull/8085)
  * K3s's external apiserver listener now declines to add to its certificate any subject names not associated with the kubernetes apiserver service, server nodes, or values of the --tls-san option. This prevents the certificate's SAN list from being filled with unwanted entries.
* Bump docker/docker to master commit; cri-dockerd to 0.3.4 [(#8092)](https://github.com/k3s-io/k3s/pull/8092)
  * Bump docker/docker module version to fix issues with cri-dockerd caused by recent releases of golang rejecting invalid host headers sent by the docker client.
* Bump versions for etcd, containerd, runc [(#8109)](https://github.com/k3s-io/k3s/pull/8109)
  * Updated the embedded containerd to v1.7.3+k3s1
  * Updated the embedded runc to v1.1.8
  * Updated the embedded etcd to v3.5.9+k3s1
* Etcd snapshots retention when node name changes [(#8099)](https://github.com/k3s-io/k3s/pull/8099)
* Bump kine to v0.10.2 [(#8125)](https://github.com/k3s-io/k3s/pull/8125)
  * Updated kine to v0.10.2
* Remove terraform package [(#8136)](https://github.com/k3s-io/k3s/pull/8136)
* Fix etcd-snapshot delete when etcd-s3 is true [(#8110)](https://github.com/k3s-io/k3s/pull/8110)
* Add --disable-cloud-controller and --disable-kube-proxy test [(#8018)](https://github.com/k3s-io/k3s/pull/8018)
* Use `go list -m` instead of grep to look up versions [(#8138)](https://github.com/k3s-io/k3s/pull/8138)
* Use VERSION_K8S in tests instead of grep go.mod [(#8147)](https://github.com/k3s-io/k3s/pull/8147)
* Fix for Kubeflag Integration test [(#8154)](https://github.com/k3s-io/k3s/pull/8154)
* Fix for cluster-reset backup from s3 when etcd snapshots are disabled [(#8155)](https://github.com/k3s-io/k3s/pull/8155)
* Run integration test CI in parallel [(#8156)](https://github.com/k3s-io/k3s/pull/8156)
* Bump Trivy version [(#8150)](https://github.com/k3s-io/k3s/pull/8150)
* Bump Trivy version [(#8178)](https://github.com/k3s-io/k3s/pull/8178)
* Fixed the etcd retention to delete orphaned snapshots based on the date [(#8177)](https://github.com/k3s-io/k3s/pull/8177)
* Bump dynamiclistener [(#8193)](https://github.com/k3s-io/k3s/pull/8193)
  * Bumped dynamiclistener to address an issue that could cause the apiserver/supervisor listener on 6443 to stop serving requests on etcd-only nodes.
  * The K3s external apiserver/supervisor listener on 6443 now sends a complete certificate chain in the TLS handshake.
* Bump helm-controller/klipper-helm versions [(#8204)](https://github.com/k3s-io/k3s/pull/8204)
  * The version of `helm` used by the bundled helm controller's job image has been updated to v3.12.3
* E2E: Add test for `k3s token` [(#8184)](https://github.com/k3s-io/k3s/pull/8184)
* Move flannel to 0.22.2 [(#8219)](https://github.com/k3s-io/k3s/pull/8219)
  * Move flannel to v0.22.2
* Add new CLI flag to enable TLS SAN CN filtering [(#8257)](https://github.com/k3s-io/k3s/pull/8257)
  * Added a new `--tls-san-security` option. This flag defaults to false, but can be set to true to disable automatically adding SANs to the server's TLS certificate to satisfy any hostname requested by a client.
* Add RWMutex to address controller [(#8273)](https://github.com/k3s-io/k3s/pull/8273)
* Update to v1.27.5 [(#8236)](https://github.com/k3s-io/k3s/pull/8236)

## Embedded Component Versions
| Component | Version |
|---|---|
| Kubernetes | [v1.27.5](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.27.md#v1275) |
| Kine | [v0.10.2](https://github.com/k3s-io/kine/releases/tag/v0.10.2) |
| SQLite | [3.42.0](https://sqlite.org/releaselog/3_42_0.html) |
| Etcd | [v3.5.9-k3s1](https://github.com/k3s-io/etcd/releases/tag/v3.5.9-k3s1) |
| Containerd | [v1.7.3-k3s1](https://github.com/k3s-io/containerd/releases/tag/v1.7.3-k3s1) |
| Runc | [v1.1.8](https://github.com/opencontainers/runc/releases/tag/v1.1.8) |
| Flannel | [v0.22.2](https://github.com/flannel-io/flannel/releases/tag/v0.22.2) | 
| Metrics-server | [v0.6.3](https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.6.3) |
| Traefik | [v2.9.10](https://github.com/traefik/traefik/releases/tag/v2.9.10) |
| CoreDNS | [v1.10.1](https://github.com/coredns/coredns/releases/tag/v1.10.1) | 
| Helm-controller | [v0.15.4](https://github.com/k3s-io/helm-controller/releases/tag/v0.15.4) |
| Local-path-provisioner | [v0.0.24](https://github.com/rancher/local-path-provisioner/releases/tag/v0.0.24) |

## Helpful Links
As always, we welcome and appreciate feedback from our community of users. Please feel free to:
- [Open issues here](https://github.com/rancher/k3s/issues/new/choose)
- [Join our Slack channel](https://slack.rancher.io/)
- [Check out our documentation](https://rancher.com/docs/k3s/latest/en/) for guidance on how to get started or to dive deep into K3s.
- [Read how you can contribute here](https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md)