### PR TITLE
Minor: k3s update from v1.28.2+k3s1 to v1.28.3+k3s2

### DIFF
--- a/inventory/pi-cluster/group_vars/all.yml
+++ b/inventory/pi-cluster/group_vars/all.yml
@@ -4,7 +4,7 @@ ansible_user: charles
 k3s_state: installed # 'uninstalled' to uninstall k3s
 k3s_pods_cidr: 10.42.0.0/16
 k3s_github_url: https://github.com/k3s-io/k3s
-k3s_release_version: v1.28.2+k3s1
+k3s_release_version: v1.28.3+k3s2
 k3s_etcd_datastore: true
 k3s_become: true
 


### PR DESCRIPTION
<!-- v1.28.3+k3s2 -->

This release updates Kubernetes to v1.28.3, and fixes a number of issues.

For more details on what's new, see the [Kubernetes release notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.28.md#changelog-since-v1283).

## Changes since v1.28.3+k3s1:

* Restore selinux context systemd unit file [(#8593)](https://github.com/k3s-io/k3s/pull/8593)
* Update channel to v1.27.7+k3s1 [(#8753)](https://github.com/k3s-io/k3s/pull/8753)
* Bump Sonobuoy version [(#8710)](https://github.com/k3s-io/k3s/pull/8710)
* Bump Trivy version [(#8739)](https://github.com/k3s-io/k3s/pull/8739)
* Fix: Access outer scope .SystemdCgroup [(#8761)](https://github.com/k3s-io/k3s/pull/8761)
  * Fixed failing to start with nvidia-container-runtime
* Upgrade traefik chart to v25.0.0 [(#8771)](https://github.com/k3s-io/k3s/pull/8771)
* Update traefik to fix registry value [(#8792)](https://github.com/k3s-io/k3s/pull/8792)
* Don't use iptables-save/iptables-restore if it will corrupt rules [(#8795)](https://github.com/k3s-io/k3s/pull/8795)

## Embedded Component Versions
| Component | Version |
|---|---|
| Kubernetes | [v1.28.3](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.28.md#v1283) |
| Kine | [v0.10.3](https://github.com/k3s-io/kine/releases/tag/v0.10.3) |
| SQLite | [3.42.0](https://sqlite.org/releaselog/3_42_0.html) |
| Etcd | [v3.5.9-k3s1](https://github.com/k3s-io/etcd/releases/tag/v3.5.9-k3s1) |
| Containerd | [v1.7.7-k3s1](https://github.com/k3s-io/containerd/releases/tag/v1.7.7-k3s1) |
| Runc | [v1.1.8](https://github.com/opencontainers/runc/releases/tag/v1.1.8) |
| Flannel | [v0.22.2](https://github.com/flannel-io/flannel/releases/tag/v0.22.2) | 
| Metrics-server | [v0.6.3](https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.6.3) |
| Traefik | [v2.10.5](https://github.com/traefik/traefik/releases/tag/v2.10.5) |
| CoreDNS | [v1.10.1](https://github.com/coredns/coredns/releases/tag/v1.10.1) | 
| Helm-controller | [v0.15.4](https://github.com/k3s-io/helm-controller/releases/tag/v0.15.4) |
| Local-path-provisioner | [v0.0.24](https://github.com/rancher/local-path-provisioner/releases/tag/v0.0.24) |

## Helpful Links
As always, we welcome and appreciate feedback from our community of users. Please feel free to:
- [Open issues here](https://github.com/rancher/k3s/issues/new/choose)
- [Join our Slack channel](https://slack.rancher.io/)
- [Check out our documentation](https://rancher.com/docs/k3s/latest/en/) for guidance on how to get started or to dive deep into K3s.
- [Read how you can contribute here](https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md)
