### PR TITLE
Minor: k3s update from v1.28.2+k3s1 to v1.28.4+k3s2

### DIFF
--- a/inventory/pi-cluster/group_vars/all.yml
+++ b/inventory/pi-cluster/group_vars/all.yml
@@ -4,7 +4,7 @@ ansible_user: charles
 k3s_state: installed # 'uninstalled' to uninstall k3s
 k3s_pods_cidr: 10.42.0.0/16
 k3s_github_url: https://github.com/k3s-io/k3s
-k3s_release_version: v1.28.2+k3s1
+k3s_release_version: v1.28.4+k3s2
 k3s_etcd_datastore: true
 k3s_become: true
 


### PR DESCRIPTION
<!-- v1.28.4+k3s2 -->

This release updates Kubernetes to v1.28.4, and fixes a number of issues.

For more details on what's new, see the [Kubernetes release notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.28.md#changelog-since-v1283).

## Changes since v1.28.3+k3s2:

* Update channels latest to v1.27.7+k3s2 [(#8799)](https://github.com/k3s-io/k3s/pull/8799)
* Add etcd status condition [(#8724)](https://github.com/k3s-io/k3s/pull/8724)
  * Now the user can see the etcd status from each node in a simple way
* ADR for etcd status [(#8355)](https://github.com/k3s-io/k3s/pull/8355)
* Wasm shims detection [(#8751)](https://github.com/k3s-io/k3s/pull/8751)
  * Automatic discovery of WebAssembly runtimes
* Add warning for removal of multiclustercidr flag [(#8758)](https://github.com/k3s-io/k3s/pull/8758)
* Improve dualStack log [(#8798)](https://github.com/k3s-io/k3s/pull/8798)
* Optimize: Simplify and clean up Dockerfile [(#8244)](https://github.com/k3s-io/k3s/pull/8244)
* Add: timezone info in image [(#8764)](https://github.com/k3s-io/k3s/pull/8764)
  * - New timezone info in Docker image allows the use of `spec.timeZone` in CronJobs
* Bump kine to fix nats, postgres, and watch issues [(#8778)](https://github.com/k3s-io/k3s/pull/8778)
  * Bumped kine to v0.11.0 to resolve issues with postgres and NATS, fix performance of watch channels under heavy load, and improve compatibility with the reference implementation.
* QoS-class resource configuration [(#8726)](https://github.com/k3s-io/k3s/pull/8726)
  * Containerd may now be configured to use rdt or blockio configuration by defining `rdt_config.yaml` or `blockio_config.yaml` files.
* Add agent flag disable-apiserver-lb [(#8717)](https://github.com/k3s-io/k3s/pull/8717)
  * Add agent flag disable-apiserver-lb, agent will not start load balance proxy.
* Force umount for NFS mount (like with longhorn) [(#8521)](https://github.com/k3s-io/k3s/pull/8521)
* General updates to README [(#8786)](https://github.com/k3s-io/k3s/pull/8786)
* Fix wrong warning from restorecon in install script [(#8871)](https://github.com/k3s-io/k3s/pull/8871)
* Fix issue with snapshot metadata configmap [(#8835)](https://github.com/k3s-io/k3s/pull/8835)
  * Omit snapshot list configmap entries for snapshots without extra metadata
* Skip initial datastore reconcile during cluster-reset [(#8861)](https://github.com/k3s-io/k3s/pull/8861)
* Tweaked order of ingress IPs in ServiceLB [(#8711)](https://github.com/k3s-io/k3s/pull/8711)
  * Improved ingress IP ordering from ServiceLB
* Disable helm CRD installation for disable-helm-controller [(#8702)](https://github.com/k3s-io/k3s/pull/8702)
* More improves for K3s patch release docs [(#8800)](https://github.com/k3s-io/k3s/pull/8800)
* Update install.sh sha256sum [(#8885)](https://github.com/k3s-io/k3s/pull/8885)
* Add jitter to client config retry to avoid hammering servers when they are starting up [(#8863)](https://github.com/k3s-io/k3s/pull/8863)
* Handle nil pointer when runtime core is not ready in etcd [(#8886)](https://github.com/k3s-io/k3s/pull/8886)
* Bump dynamiclistener; reduce snapshot controller log spew [(#8894)](https://github.com/k3s-io/k3s/pull/8894)
  * Bumped dynamiclistener to address a race condition that could cause a server to fail to sync its certificates into the Kubernetes secret
  * Reduced etcd snapshot log spam during initial cluster startup
* Remove depends_on for e2e step; fix cert rotate e2e [(#8906)](https://github.com/k3s-io/k3s/pull/8906)
* Fix etcd snapshot S3 issues [(#8926)](https://github.com/k3s-io/k3s/pull/8926)
  * Don't apply S3 retention if S3 client failed to initialize
  * Don't request metadata when listing S3 snapshots
  * Print key instead of file path in snapshot metadata log message
* Update to v1.28.4 and Go to v1.20.11 [(#8920)](https://github.com/k3s-io/k3s/pull/8920)
* Remove s390x steps temporarily since runners are disabled [(#8983)](https://github.com/k3s-io/k3s/pull/8983)
* Remove s390x from manifest [(#8998)](https://github.com/k3s-io/k3s/pull/8998)

## Embedded Component Versions
| Component | Version |
|---|---|
| Kubernetes | [v1.28.4](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.28.md#v1284) |
| Kine | [v0.11.0](https://github.com/k3s-io/kine/releases/tag/v0.11.0) |
| SQLite | [3.42.0](https://sqlite.org/releaselog/3_42_0.html) |
| Etcd | [v3.5.9-k3s1](https://github.com/k3s-io/etcd/releases/tag/v3.5.9-k3s1) |
| Containerd | [v1.7.7-k3s1](https://github.com/k3s-io/containerd/releases/tag/v1.7.7-k3s1) |
| Runc | [v1.1.8](https://github.com/opencontainers/runc/releases/tag/v1.1.8) |
| Flannel | [v0.22.2](https://github.com/flannel-io/flannel/releases/tag/v0.22.2) |
| Metrics-server | [v0.6.3](https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.6.3) |
| Traefik | [v2.10.5](https://github.com/traefik/traefik/releases/tag/v2.10.5) |
| CoreDNS | [v1.10.1](https://github.com/coredns/coredns/releases/tag/v1.10.1) |
| Helm-controller | [v0.15.4](https://github.com/k3s-io/helm-controller/releases/tag/v0.15.4) |
| Local-path-provisioner | [v0.0.24](https://github.com/rancher/local-path-provisioner/releases/tag/v0.0.24) |

## Helpful Links
As always, we welcome and appreciate feedback from our community of users. Please feel free to:
- [Open issues here](https://github.com/rancher/k3s/issues/new/choose)
- [Join our Slack channel](https://slack.rancher.io/)
- [Check out our documentation](https://rancher.com/docs/k3s/latest/en/) for guidance on how to get started or to dive deep into K3s.
- [Read how you can contribute here](https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md)