### PR TITLE
new release: k3s update from v1.28.4+k3s2 to v1.29.0+k3s1

### DIFF
--- a/inventory/pi-cluster/group_vars/all.yml
+++ b/inventory/pi-cluster/group_vars/all.yml
@@ -4,7 +4,7 @@ ansible_user: charles
 k3s_state: installed # 'uninstalled' to uninstall k3s
 k3s_pods_cidr: 10.42.0.0/16
 k3s_github_url: https://github.com/k3s-io/k3s
-k3s_release_version: v1.28.4+k3s2
+k3s_release_version: v1.29.0+k3s1
 k3s_become: true
 
 # Use etcd as an embedded datastore.


### PR DESCRIPTION
<!-- v1.29.0+k3s1 -->

This release is K3S's first in the v1.29 line. This release updates Kubernetes to v1.29.0.

Before upgrading from earlier releases, be sure to read the Kubernetes [Urgent Upgrade Notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.29.md#urgent-upgrade-notes).

⚠️ IMPORTANT: This release removes the expiremental `rotate-keys` subcommand due to changes in Kubernetes upstream for [KMSv2](https://github.com/kubernetes/kubernetes/issues/117728), the subcommand should be added back in future releases.

⚠️ IMPORTANT: This release also removes the `multi-cluster-cidr` flag, since the support for this alpha feature has been removed completely from [Kubernetes upstream](https://groups.google.com/g/kubernetes-sig-network/c/nts1xEZ--gQ/m/2aTOUNFFAAAJ), this flag should be removed from the configuration before upgrade.


## Changes since v1.28.4+k3s2:

* Fix overlapping address range [(#8913)](https://github.com/k3s-io/k3s/pull/8913)
* Modify CONTRIBUTING.md guide [(#8954)](https://github.com/k3s-io/k3s/pull/8954)
* Nov 2023 stable channel update [(#9022)](https://github.com/k3s-io/k3s/pull/9022)
* Default runtime and runtime classes for wasm/nvidia/crun [(#8936)](https://github.com/k3s-io/k3s/pull/8936)
  * Added runtime classes for wasm/nvidia/crun
  * Added default runtime flag for containerd
* Bump containerd/runc to v1.7.10-k3s1/v1.1.10 [(#8962)](https://github.com/k3s-io/k3s/pull/8962)
* Allow setting default-runtime on servers [(#9027)](https://github.com/k3s-io/k3s/pull/9027)
* Bump containerd to v1.7.11 [(#9040)](https://github.com/k3s-io/k3s/pull/9040)
* Remove GA feature-gates [(#8970)](https://github.com/k3s-io/k3s/pull/8970)
* Only publish to code_cov on merged E2E builds [(#9051)](https://github.com/k3s-io/k3s/pull/9051)
* Update Kubernetes to v1.29.0+k3s1 [(#9052)](https://github.com/k3s-io/k3s/pull/9052)
* Update flannel to v0.24.0 and remove multiclustercidr flag [(#9075)](https://github.com/k3s-io/k3s/pull/9075)
* Remove rotate-keys subcommand [(#9079)](https://github.com/k3s-io/k3s/pull/9079)

## Embedded Component Versions
| Component | Version |
|---|---|
| Kubernetes | [v1.29.0](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.29.md#v1290) |
| Kine | [v0.11.0](https://github.com/k3s-io/kine/releases/tag/v0.11.0) |
| SQLite | [3.42.0](https://sqlite.org/releaselog/3_42_0.html) |
| Etcd | [v3.5.9-k3s1](https://github.com/k3s-io/etcd/releases/tag/v3.5.9-k3s1) |
| Containerd | [v1.7.11-k3s2](https://github.com/k3s-io/containerd/releases/tag/v1.7.11-k3s2) |
| Runc | [v1.1.10](https://github.com/opencontainers/runc/releases/tag/v1.1.10) |
| Flannel | [v0.24.0](https://github.com/flannel-io/flannel/releases/tag/v0.24.0) | 
| Metrics-server | [v0.6.3](https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.6.3) |
| Traefik | [v2.10.5](https://github.com/traefik/traefik/releases/tag/v2.10.5) |
| CoreDNS | [v1.10.1](https://github.com/coredns/coredns/releases/tag/v1.10.1) | 
| Helm-controller | [v0.15.4](https://github.com/k3s-io/helm-controller/releases/tag/v0.15.4) |
| Local-path-provisioner | [v0.0.24](https://github.com/rancher/local-path-provisioner/releases/tag/v0.0.24) |

## Helpful Links
As always, we welcome and appreciate feedback from our community of users. Please feel free to:
- [Open issues here](https://github.com/rancher/k3s/issues/new/choose)
- [Join our Slack channel](https://slack.rancher.io/)
- [Check out our documentation](https://rancher.com/docs/k3s/latest/en/) for guidance on how to get started or to dive deep into K3s.
- [Read how you can contribute here](https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md)