### PR TITLE
new release: k3s update from v1.30.4+k3s1 to v1.31.0+k3s1

### DIFF
--- a/inventory/cluster/group_vars/all.yml
+++ b/inventory/cluster/group_vars/all.yml
@@ -4,7 +4,7 @@ ansible_user: charles
 k3s_state: installed # 'uninstalled' to uninstall k3s
 k3s_pods_cidr: 10.42.0.0/16
 k3s_github_url: https://github.com/k3s-io/k3s
-k3s_release_version: v1.30.4+k3s1
+k3s_release_version: v1.31.0+k3s1
 k3s_become: true
 
 # Use etcd as an embedded datastore.


### PR DESCRIPTION
<!-- v1.31.0+k3s1 -->

This release is K3S's first in the v1.31 line. This release updates Kubernetes to v1.31.0.

For more details on what's new, see the [Kubernetes release notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.31.md#changelog-since-v1300).

## Changes since v1.30.4+k3s1:

* Move test-compat docker test to GHA [(#10414)](https://github.com/k3s-io/k3s/pull/10414)
* Check for bad token permissions when install via PR [(#10387)](https://github.com/k3s-io/k3s/pull/10387)
* Bump k3s-root to v0.14.0 [(#10466)](https://github.com/k3s-io/k3s/pull/10466)
  * The k3s bundled userspace has been bumped to a release based on buildroot 2024.02.3, addressing several CVEs in busybox and coreutils.
* Fix INSTALL_K3S_PR support [(#10472)](https://github.com/k3s-io/k3s/pull/10472)
* Add `data-dir` to uninstall and killall scripts [(#10473)](https://github.com/k3s-io/k3s/pull/10473)
* Bump github.com/hashicorp/go-retryablehttp from 0.7.4 to 0.7.7 [(#10400)](https://github.com/k3s-io/k3s/pull/10400)
* Bump golang:alpine image version [(#10359)](https://github.com/k3s-io/k3s/pull/10359)
* Bump Local Path Provisioner version [(#10394)](https://github.com/k3s-io/k3s/pull/10394)
* Ensure remotedialer kubelet connections use kubelet bind address [(#10480)](https://github.com/k3s-io/k3s/pull/10480)
  * Fixed an issue where setting the `--bind-address` flag to a non-loopback or wildcard address would prevent `kubectl logs` from working properly.
* Bump Trivy version [(#10339)](https://github.com/k3s-io/k3s/pull/10339)
* Add etcd s3 config secret implementation [(#10340)](https://github.com/k3s-io/k3s/pull/10340)
  * A proxy can now be configured for use when uploading etcd snapshots to a s3-compatible storage service. This overrides any proxy settings passed via environment variables.
  * Credentials and endpoint configuration for storing etcd snapshots on a s3-compatible storage service can now be read from a Secret, instead of passing them via the CLI or config file. See https://github.com/k3s-io/k3s/blob/master/docs/adrs/etcd-s3-secret.md for more information.
* For E2E upgrade test, automatically determine the channel to use [(#10461)](https://github.com/k3s-io/k3s/pull/10461)
* Bump kine to v0.11.11 [(#10494)](https://github.com/k3s-io/k3s/pull/10494)
* Fix loadbalancer reentrant rlock [(#10511)](https://github.com/k3s-io/k3s/pull/10511)
  * Fixed an issue that could cause the agent loadbalancer to deadlock when the currently in-use server goes down.
* Don't use server value from config file for etcd-snapshot commands [(#10514)](https://github.com/k3s-io/k3s/pull/10514)
  * The `--server` and `--token` flags for the `k3s etcd-snapshot` command have been renamed to `--etcd-server` and `--etcd-token`, to avoid unintentionally running snapshot management commands against a remote node when the cluster join address or token are present in a config file.
* Use pagination when listing large numbers of resources [(#10527)](https://github.com/k3s-io/k3s/pull/10527)
* Fix multiple issues with servicelb [(#10552)](https://github.com/k3s-io/k3s/pull/10552)
  * Fixed issue that caused ServiceLB to fail to create a daemonset for services with long names
  * Fixed issue that caused ServiceLB pods to crashloop on nodes with ipv6 disabled at the kernel level
* Enhance E2E Hardened option [(#10558)](https://github.com/k3s-io/k3s/pull/10558)
* Allow Pprof and Superisor metrics in standalone mode [(#10576)](https://github.com/k3s-io/k3s/pull/10576)
* Use higher QPS for secrets reencryption [(#10571)](https://github.com/k3s-io/k3s/pull/10571)
* Fix issues loading data-dir value from env vars or dropin config files [(#10591)](https://github.com/k3s-io/k3s/pull/10591)
* Remove deprecated use of wait. functions [(#10546)](https://github.com/k3s-io/k3s/pull/10546)
* Wire lasso metrics up to metrics endpoint [(#10528)](https://github.com/k3s-io/k3s/pull/10528)
* Update stable channel to v1.30.3+k3s1 [(#10647)](https://github.com/k3s-io/k3s/pull/10647)
* Bump docker/docker to v25.0.6 [(#10642)](https://github.com/k3s-io/k3s/pull/10642)
* Add a change for killall to not unmount server and agent directory [(#10403)](https://github.com/k3s-io/k3s/pull/10403)
* Allow edge case OS rpm installs [(#10680)](https://github.com/k3s-io/k3s/pull/10680)
* Bump containerd to v1.7.20 [(#10659)](https://github.com/k3s-io/k3s/pull/10659)
* Update to newer OS images for install testing [(#10681)](https://github.com/k3s-io/k3s/pull/10681)
* Bump helm-controller to v0.16.3 to drop Helm v2 support [(#10628)](https://github.com/k3s-io/k3s/pull/10628)
* Add toleration support to ServiceLB DaemonSet [(#10687)](https://github.com/k3s-io/k3s/pull/10687)
  * - **New Feature**: Users can now define Kubernetes tolerations for ServiceLB DaemonSet directly in the `svccontroller.k3s.cattle.io/tolerations` annotation on services.
* Fix: Add $SUDO prefix to transactional-update commands in install script [(#10531)](https://github.com/k3s-io/k3s/pull/10531)
* Update to v1.30.3-k3s1 and Go 1.22.5 [(#10707)](https://github.com/k3s-io/k3s/pull/10707)
* Fix caching name for e2e vagrant box [(#10695)](https://github.com/k3s-io/k3s/pull/10695)
* Fix k3s-killall.sh support for custom data dir [(#10709)](https://github.com/k3s-io/k3s/pull/10709)
* Adding MariaDB to README.md [(#10717)](https://github.com/k3s-io/k3s/pull/10717)
* Bump Trivy version [(#10670)](https://github.com/k3s-io/k3s/pull/10670)
* V1.31.0-k3s1 [(#10715)](https://github.com/k3s-io/k3s/pull/10715)
* Update kubernetes to v1.31.0-k3s3 [(#10780)](https://github.com/k3s-io/k3s/pull/10780)

## Embedded Component Versions
| Component | Version |
|---|---|
| Kubernetes | [v1.31.0](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.31.md#v1310) |
| Kine | [v0.12.0](https://github.com/k3s-io/kine/releases/tag/v0.12.0) |
| SQLite | [3.44.0](https://sqlite.org/releaselog/3_44_0.html) |
| Etcd | [v3.5.13-k3s1](https://github.com/k3s-io/etcd/releases/tag/v3.5.13-k3s1) |
| Containerd | [v1.7.20-k3s1](https://github.com/k3s-io/containerd/releases/tag/v1.7.20-k3s1) |
| Runc | [v1.1.12](https://github.com/opencontainers/runc/releases/tag/v1.1.12) |
| Flannel | [v0.25.4](https://github.com/flannel-io/flannel/releases/tag/v0.25.4) |
| Metrics-server | [v0.7.0](https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.7.0) |
| Traefik | [v2.10.7](https://github.com/traefik/traefik/releases/tag/v2.10.7) |
| CoreDNS | [v1.10.1](https://github.com/coredns/coredns/releases/tag/v1.10.1) |
| Helm-controller | [v0.16.3](https://github.com/k3s-io/helm-controller/releases/tag/v0.16.3) |
| Local-path-provisioner | [v0.0.28](https://github.com/rancher/local-path-provisioner/releases/tag/v0.0.28) |

## Helpful Links
As always, we welcome and appreciate feedback from our community of users. Please feel free to:
- [Open issues here](https://github.com/rancher/k3s/issues/new/choose)
- [Join our Slack channel](https://slack.rancher.io/)
- [Check out our documentation](https://rancher.com/docs/k3s/latest/en/) for guidance on how to get started or to dive deep into K3s.
- [Read how you can contribute here](https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md)
