### PR TITLE
new release: k3s update from v1.31.0+k3s1 to v1.31.1+k3s1

### DIFF
--- a/inventory/cluster/group_vars/all.yml
+++ b/inventory/cluster/group_vars/all.yml
@@ -4,7 +4,7 @@ ansible_user: charles
 k3s_state: installed # 'uninstalled' to uninstall k3s
 k3s_pods_cidr: 10.42.0.0/16
 k3s_github_url: https://github.com/k3s-io/k3s
-k3s_release_version: v1.31.0+k3s1
+k3s_release_version: v1.31.1+k3s1
 k3s_become: true
 
 # Use etcd as an embedded datastore.


### PR DESCRIPTION
<!-- v1.31.1+k3s1 -->

This release updates Kubernetes to v1.31.1, and fixes a number of issues.

For more details on what's new, see the [Kubernetes release notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.31.md#changelog-since-v1310).

## Changes since v1.31.0+k3s1:

* Testing And Secrets-Encryption Backports for 2024-09 [(#10802)](https://github.com/k3s-io/k3s/pull/10802)
  * Remove secrets encryption controller
  * Cover edge case when on new minor release for E2E upgrade test
* Update CNI plugins version [(#10817)](https://github.com/k3s-io/k3s/pull/10817)
* Backports for 2024-09 [(#10842)](https://github.com/k3s-io/k3s/pull/10842)
* Fix hosts.toml header var [(#10871)](https://github.com/k3s-io/k3s/pull/10871)
* Update Kubernetes to v1.31.1 [(#10895)](https://github.com/k3s-io/k3s/pull/10895)
* Update Kubernetes to v1.31.1-k3s3 [(#10910)](https://github.com/k3s-io/k3s/pull/10910)

## Embedded Component Versions
| Component | Version |
|---|---|
| Kubernetes | [v1.31.1](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.31.md#v1311) |
| Kine | [v0.12.0](https://github.com/k3s-io/kine/releases/tag/v0.12.0) |
| SQLite | [3.44.0](https://sqlite.org/releaselog/3_44_0.html) |
| Etcd | [v3.5.13-k3s1](https://github.com/k3s-io/etcd/releases/tag/v3.5.13-k3s1) |
| Containerd | [v1.7.21-k3s2](https://github.com/k3s-io/containerd/releases/tag/v1.7.21-k3s2) |
| Runc | [v1.1.14](https://github.com/opencontainers/runc/releases/tag/v1.1.14) |
| Flannel | [v0.25.6](https://github.com/flannel-io/flannel/releases/tag/v0.25.6) |
| Metrics-server | [v0.7.2](https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.7.2) |
| Traefik | [v2.11.8](https://github.com/traefik/traefik/releases/tag/v2.11.8) |
| CoreDNS | [v1.11.3](https://github.com/coredns/coredns/releases/tag/v1.11.3) | 
| Helm-controller | [v0.16.4](https://github.com/k3s-io/helm-controller/releases/tag/v0.16.4) |
| Local-path-provisioner | [v0.0.28](https://github.com/rancher/local-path-provisioner/releases/tag/v0.0.28) |

## Helpful Links
As always, we welcome and appreciate feedback from our community of users. Please feel free to:
- [Open issues here](https://github.com/rancher/k3s/issues/new/choose)
- [Join our Slack channel](https://slack.rancher.io/)
- [Check out our documentation](https://rancher.com/docs/k3s/latest/en/) for guidance on how to get started or to dive deep into K3s.
- [Read how you can contribute here](https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md)
