### PR TITLE
new release: k3s update from v1.31.1+k3s1 to v1.31.2+k3s1

### DIFF
--- a/inventory/cluster/group_vars/all.yml
+++ b/inventory/cluster/group_vars/all.yml
@@ -4,7 +4,7 @@ ansible_user: charles
 k3s_state: installed # 'uninstalled' to uninstall k3s
 k3s_pods_cidr: 10.42.0.0/16
 k3s_github_url: https://github.com/k3s-io/k3s
-k3s_release_version: v1.31.1+k3s1
+k3s_release_version: v1.31.2+k3s1
 k3s_become: true
 
 # Use etcd as an embedded datastore.


### PR DESCRIPTION
<!-- v1.31.2+k3s1 -->

This release updates Kubernetes to v1.31.2, and fixes a number of issues.

For more details on what's new, see the [Kubernetes release notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.31.md#changelog-since-v1311).

## Changes since v1.31.1+k3s1:

* Add int test for flannel-ipv6masq [(#10904)](https://github.com/k3s-io/k3s/pull/10904)
* Bump Wharfie to v0.6.7 [(#10974)](https://github.com/k3s-io/k3s/pull/10974)
* Add user path to runtimes search [(#11002)](https://github.com/k3s-io/k3s/pull/11002)
* Add e2e test for advanced fields in services [(#11023)](https://github.com/k3s-io/k3s/pull/11023)
* Launch private registry with init [(#11048)](https://github.com/k3s-io/k3s/pull/11048)
* Backports for 2024-10 [(#11054)](https://github.com/k3s-io/k3s/pull/11054)
* Allow additional Rootless CopyUpDirs through K3S_ROOTLESS_COPYUPDIRS [(#11041)](https://github.com/k3s-io/k3s/pull/11041)
* Bump containerd to v1.7.22 [(#11072)](https://github.com/k3s-io/k3s/pull/11072)
* Simplify svclb ds [(#11079)](https://github.com/k3s-io/k3s/pull/11079)
* Add the nvidia runtime cdi [(#11093)](https://github.com/k3s-io/k3s/pull/11093)
* Revert "Make svclb as simple as possible" [(#11118)](https://github.com/k3s-io/k3s/pull/11118)
* Fixes "file exists" error from CNI bins when upgrading k3s [(#11125)](https://github.com/k3s-io/k3s/pull/11125)
* Update Kubernetes to v1.31.2 [(#11155)](https://github.com/k3s-io/k3s/pull/11155)

## Embedded Component Versions
| Component | Version |
|---|---|
| Kubernetes | [v1.31.2](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.31.md#v1312) |
| Kine | [v0.13.2](https://github.com/k3s-io/kine/releases/tag/v0.13.2) |
| SQLite | [3.46.1](https://sqlite.org/releaselog/3_46_1.html) |
| Etcd | [v3.5.13-k3s1](https://github.com/k3s-io/etcd/releases/tag/v3.5.13-k3s1) |
| Containerd | [v1.7.22-k3s1](https://github.com/k3s-io/containerd/releases/tag/v1.7.22-k3s1) |
| Runc | [v1.1.14](https://github.com/opencontainers/runc/releases/tag/v1.1.14) |
| Flannel | [v0.25.6](https://github.com/flannel-io/flannel/releases/tag/v0.25.6) | 
| Metrics-server | [v0.7.2](https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.7.2) |
| Traefik | [v2.11.10](https://github.com/traefik/traefik/releases/tag/v2.11.10) |
| CoreDNS | [v1.11.3](https://github.com/coredns/coredns/releases/tag/v1.11.3) | 
| Helm-controller | [v0.16.5](https://github.com/k3s-io/helm-controller/releases/tag/v0.16.5) |
| Local-path-provisioner | [v0.0.30](https://github.com/rancher/local-path-provisioner/releases/tag/v0.0.30) |

## Helpful Links
As always, we welcome and appreciate feedback from our community of users. Please feel free to:
- [Open issues here](https://github.com/rancher/k3s/issues/new/choose)
- [Join our Slack channel](https://slack.rancher.io/)
- [Check out our documentation](https://rancher.com/docs/k3s/latest/en/) for guidance on how to get started or to dive deep into K3s.
- [Read how you can contribute here](https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md)
