### PR TITLE
new release: k3s update from v1.32.0+k3s1 to v1.32.1+k3s1

### DIFF
--- a/inventory/cluster/group_vars/all.yml
+++ b/inventory/cluster/group_vars/all.yml
@@ -4,7 +4,7 @@ ansible_user: charles
 k3s_state: installed # 'uninstalled' to uninstall k3s
 k3s_pods_cidr: 10.42.0.0/16
 k3s_github_url: https://github.com/k3s-io/k3s
-k3s_release_version: v1.32.0+k3s1
+k3s_release_version: v1.32.1+k3s1
 k3s_become: true
 
 # Use etcd as an embedded datastore.


### PR DESCRIPTION
<!-- v1.32.1+k3s1 -->

This release updates Kubernetes to v1.32.1, and fixes a number of issues.

For more details on what's new, see the [Kubernetes release notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.32.md#changelog-since-v1320).

## Changes since v1.32.0+k3s1:

* Backports for 2025-01 [(#11565)](https://github.com/k3s-io/k3s/pull/11565)
* Add auto import images for containerd image store [(#11563)](https://github.com/k3s-io/k3s/pull/11563)
* 2025 January Backports [(#11583)](https://github.com/k3s-io/k3s/pull/11583)
* Fix local password validation when bind-address is set [(#11610)](https://github.com/k3s-io/k3s/pull/11610)
* Update to v1.32.1-k3s1 and Go 1.23.4 [(#11620)](https://github.com/k3s-io/k3s/pull/11620)
* Remove local restriction for deferred node password validation [(#11648)](https://github.com/k3s-io/k3s/pull/11648)

## Embedded Component Versions
| Component | Version |
|---|---|
| Kubernetes | [v1.32.1](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.32.md#v1321) |
| Kine | [v0.13.5](https://github.com/k3s-io/kine/releases/tag/v0.13.5) |
| SQLite | [3.46.1](https://sqlite.org/releaselog/3_46_1.html) |
| Etcd | [v3.5.16-k3s1](https://github.com/k3s-io/etcd/releases/tag/v3.5.16-k3s1) |
| Containerd | [v1.7.23-k3s2](https://github.com/k3s-io/containerd/releases/tag/v1.7.23-k3s2) |
| Runc | [v1.2.4-k3s1](https://github.com/opencontainers/runc/releases/tag/v1.2.4-k3s1) |
| Flannel | [v0.25.7](https://github.com/flannel-io/flannel/releases/tag/v0.25.7) | 
| Metrics-server | [v0.7.2](https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.7.2) |
| Traefik | [v2.11.18](https://github.com/traefik/traefik/releases/tag/v2.11.18) |
| CoreDNS | [v1.12.0](https://github.com/coredns/coredns/releases/tag/v1.12.0) | 
| Helm-controller | [v0.16.5](https://github.com/k3s-io/helm-controller/releases/tag/v0.16.5) |
| Local-path-provisioner | [v0.0.30](https://github.com/rancher/local-path-provisioner/releases/tag/v0.0.30) |

## Helpful Links
As always, we welcome and appreciate feedback from our community of users. Please feel free to:
- [Open issues here](https://github.com/rancher/k3s/issues/new/choose)
- [Join our Slack channel](https://slack.rancher.io/)
- [Check out our documentation](https://rancher.com/docs/k3s/latest/en/) for guidance on how to get started or to dive deep into K3s.
- [Read how you can contribute here](https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md)


## What's Changed
* [release-1.32] Remove local restriction for deferred node password validation by @brandond in https://github.com/k3s-io/k3s/pull/11648


**Full Changelog**: https://github.com/k3s-io/k3s/compare/v1.32.1-rc1+k3s1...v1.32.1+k3s1