### PR TITLE
new release: k3s update from v1.32.1+k3s1 to v1.32.2+k3s1

### DIFF
--- a/inventory/cluster/group_vars/all.yml
+++ b/inventory/cluster/group_vars/all.yml
@@ -4,7 +4,7 @@ ansible_user: charles
 k3s_state: installed # 'uninstalled' to uninstall k3s
 k3s_pods_cidr: 10.42.0.0/16
 k3s_github_url: https://github.com/k3s-io/k3s
-k3s_release_version: v1.32.1+k3s1
+k3s_release_version: v1.32.2+k3s1
 k3s_become: true
 
 # Use etcd as an embedded datastore.


### PR DESCRIPTION
<!-- v1.32.2+k3s1 -->

This release updates Kubernetes to v1.32.2, and fixes a number of issues.

For more details on what's new, see the [Kubernetes release notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.32.md#changelog-since-v1321).

## Changes since v1.32.1+k3s1:

* Correct the k3s token command help [(#11686)](https://github.com/k3s-io/k3s/pull/11686)
* Jan 2025 Testing Overhaul, E2E to Docker Migration, [(#11723)](https://github.com/k3s-io/k3s/pull/11723)
* Backports for 2025-02 [(#11730)](https://github.com/k3s-io/k3s/pull/11730)
  * Align the CLI-reported default `--etcd-snapshot-dir` value with the actual one (`server`, `etcd-snapshot` commands).
  * Disable s3 transport transparent compression/decompression
  * Etcd snapshot backup/restore now supports loading s3 credentials from an AWS SDK shared credentials file.
  * Bump klipper-helm to v0.9.4
  * Bump klipper-lb to v0.4.10
  * Bump spegel to v0.0.30
  * Bump local-path-provisioner to v0.0.31
  * Bump kine to v0.13.8
  * Bump etcd to v3.5.18
  * Bump traefik to 3.3.2
  * Containerd has been bumped to version 2.0.
  *   The containerd config templates for linux and windows have been consolidated and are no longer os-specific.
  *   Containerd 2.0 uses a new config file schema. If you are using a custom containerd config template, you should migrate your template to `config-v3.toml.tmpl` to switch to the new version. See the [upstream documentation](https://github.com/containerd/containerd/blob/release/2.0/docs/cri/config.md) for more information.
* Update to v1.32.2-k3s1 and Go 1.23.6 [(#11788)](https://github.com/k3s-io/k3s/pull/11788)
* Render CNI dir config whenever vars are set [(#11819)](https://github.com/k3s-io/k3s/pull/11819)
* Bump containerd for go-cni deadlock fix [(#11833)](https://github.com/k3s-io/k3s/pull/11833)

## Embedded Component Versions
| Component | Version |
|---|---|
| Kubernetes | [v1.32.2](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.32.md#v1322) |
| Kine | [v0.13.9](https://github.com/k3s-io/kine/releases/tag/v0.13.9) |
| SQLite | [3.46.1](https://sqlite.org/releaselog/3_46_1.html) |
| Etcd | [v3.5.18-k3s1](https://github.com/k3s-io/etcd/releases/tag/v3.5.18-k3s1) |
| Containerd | [v2.0.2-k3s2](https://github.com/k3s-io/containerd/releases/tag/v2.0.2-k3s2) |
| Runc | [v1.2.4-k3s1](https://github.com/opencontainers/runc/releases/tag/v1.2.4-k3s1) |
| Flannel | [v0.25.7](https://github.com/flannel-io/flannel/releases/tag/v0.25.7) | 
| Metrics-server | [v0.7.2](https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.7.2) |
| Traefik | [v3.3.2](https://github.com/traefik/traefik/releases/tag/v3.3.2) |
| CoreDNS | [v1.12.0](https://github.com/coredns/coredns/releases/tag/v1.12.0) | 
| Helm-controller | [v0.16.6](https://github.com/k3s-io/helm-controller/releases/tag/v0.16.6) |
| Local-path-provisioner | [v0.0.31](https://github.com/rancher/local-path-provisioner/releases/tag/v0.0.31) |

## Helpful Links
As always, we welcome and appreciate feedback from our community of users. Please feel free to:
- [Open issues here](https://github.com/rancher/k3s/issues/new/choose)
- [Join our Slack channel](https://slack.rancher.io/)
- [Check out our documentation](https://rancher.com/docs/k3s/latest/en/) for guidance on how to get started or to dive deep into K3s.
- [Read how you can contribute here](https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md)
