### PR TITLE
new release: k3s update from v1.32.2+k3s1 to v1.32.3+k3s1

### DIFF
--- a/inventory/cluster/group_vars/all.yml
+++ b/inventory/cluster/group_vars/all.yml
@@ -4,7 +4,7 @@ ansible_user: charles
 k3s_state: installed # 'uninstalled' to uninstall k3s
 k3s_pods_cidr: 10.42.0.0/16
 k3s_github_url: https://github.com/k3s-io/k3s
-k3s_release_version: v1.32.2+k3s1
+k3s_release_version: v1.32.3+k3s1
 k3s_become: true
 
 # Use etcd as an embedded datastore.


### PR DESCRIPTION
<!-- v1.32.3+k3s1 -->

This release updates Kubernetes to v1.32.3, and fixes a number of issues.

For more details on what's new, see the [Kubernetes release notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.32.md#changelog-since-v1322).

## Changes since v1.32.2+k3s1:

* Revert "Add ability to pass configuration options to flannel backend" [(#11867)](https://github.com/k3s-io/k3s/pull/11867)
* Backport Docker + E2E testing PRs for 2025 March [(#11888)](https://github.com/k3s-io/k3s/pull/11888)
* Backports for 2025-03 [(#11919)](https://github.com/k3s-io/k3s/pull/11919)
* Bump klipper-lb image to v0.4.13 [(#11930)](https://github.com/k3s-io/k3s/pull/11930)
* Fix syncing empty list of apiserver addresses during initial startup [(#11953)](https://github.com/k3s-io/k3s/pull/11953)
* Update to v1.32.3-k3s1 [(#11960)](https://github.com/k3s-io/k3s/pull/11960)
* Update Kubernetes to v1.32.3-k3s2 [(#11968)](https://github.com/k3s-io/k3s/pull/11968)
* Fix skew test for release candidates [(#11991)](https://github.com/k3s-io/k3s/pull/11991)
* Bump to containerd v2.0.4 [(#12003)](https://github.com/k3s-io/k3s/pull/12003)
* Fix upgrade test container version [(#12000)](https://github.com/k3s-io/k3s/pull/12000)

## Embedded Component Versions
| Component | Version |
|---|---|
| Kubernetes | [v1.32.3](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.32.md#v1323) |
| Kine | [v0.13.9](https://github.com/k3s-io/kine/releases/tag/v0.13.9) |
| SQLite | [3.46.1](https://sqlite.org/releaselog/3_46_1.html) |
| Etcd | [v3.5.19-k3s1](https://github.com/k3s-io/etcd/releases/tag/v3.5.19-k3s1) |
| Containerd | [v2.0.4-k3s2](https://github.com/k3s-io/containerd/releases/tag/v2.0.4-k3s2) |
| Runc | [v1.2.5](https://github.com/opencontainers/runc/releases/tag/v1.2.5) |
| Flannel | [v0.25.7](https://github.com/flannel-io/flannel/releases/tag/v0.25.7) | 
| Metrics-server | [v0.7.2](https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.7.2) |
| Traefik | [v3.3.2](https://github.com/traefik/traefik/releases/tag/v3.3.2) |
| CoreDNS | [v1.12.0](https://github.com/coredns/coredns/releases/tag/v1.12.0) | 
| Helm-controller | [v0.16.6](https://github.com/k3s-io/helm-controller/releases/tag/v0.16.6) |
| Local-path-provisioner | [v0.0.31](https://github.com/rancher/local-path-provisioner/releases/tag/v0.0.31) |

## Helpful Links
As always, we welcome and appreciate feedback from our community of users. Please feel free to:
- [Open issues here](https://github.com/rancher/k3s/issues/new/choose)
- [Join our Slack channel](https://slack.rancher.io/)
- [Check out our documentation](https://rancher.com/docs/k3s/latest/en/) for guidance on how to get started or to dive deep into K3s.
- [Read how you can contribute here](https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md)