### PR TITLE
new release: k3s update from v1.32.3+k3s1 to v1.32.4+k3s1

### DIFF
--- a/inventory/cluster/group_vars/all.yml
+++ b/inventory/cluster/group_vars/all.yml
@@ -4,7 +4,7 @@ ansible_user: charles
 k3s_state: installed # 'uninstalled' to uninstall k3s
 k3s_pods_cidr: 10.42.0.0/16
 k3s_github_url: https://github.com/k3s-io/k3s
-k3s_release_version: v1.32.3+k3s1
+k3s_release_version: v1.32.4+k3s1
 k3s_become: true
 
 # Use etcd as an embedded datastore.


### PR DESCRIPTION
<!-- v1.32.4+k3s1 -->

This release updates Kubernetes to v1.32.4, and fixes a number of issues.

For more details on what's new, see the [Kubernetes release notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.32.md#changelog-since-v1323).

## Changes since v1.32.3+k3s1:

* Migrate to UrfaveCLI v2 [(#12031)](https://github.com/k3s-io/k3s/pull/12031)
* Improve readiness polling on node startup [(#12038)](https://github.com/k3s-io/k3s/pull/12038)
* Fix issue caused by default authorization-mode apiserver arg [(#12042)](https://github.com/k3s-io/k3s/pull/12042)
* Fix flakey etcd startup tests [(#12050)](https://github.com/k3s-io/k3s/pull/12050)
* Cleanup anonymous and named volumes for docker tests [(#12079)](https://github.com/k3s-io/k3s/pull/12079)
* Add support for secretbox encryption provider with the `k3s secrets-encrypt` command [(#12067)](https://github.com/k3s-io/k3s/pull/12067)
  * Users can now configure secrets encryption to use `secretbox` provider by setting the `secrets-encryption-provider` flag.
* Add error in certificate check [(#12098)](https://github.com/k3s-io/k3s/pull/12098)
* Backports for 2025-04 [(#12104)](https://github.com/k3s-io/k3s/pull/12104)
* Bump kine for nats-server/v2 CVE-2025-30215 [(#12141)](https://github.com/k3s-io/k3s/pull/12141)
* Drone Test Split and Reduction [(#12151)](https://github.com/k3s-io/k3s/pull/12151)
* More backports for 2025-04 [(#12167)](https://github.com/k3s-io/k3s/pull/12167)
* Fix handler panic when bootstrapper returns empty peer list [(#12178)](https://github.com/k3s-io/k3s/pull/12178)
* Bump traefik to v3.3.6 [(#12189)](https://github.com/k3s-io/k3s/pull/12189)
* Update to v1.32.4-k3s1 and Go 1.23.6 [(#12209)](https://github.com/k3s-io/k3s/pull/12209)

## Embedded Component Versions
| Component | Version |
|---|---|
| Kubernetes | [v1.32.4](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.32.md#v1324) |
| Kine | [v0.13.14](https://github.com/k3s-io/kine/releases/tag/v0.13.14) |
| SQLite | [3.46.1](https://sqlite.org/releaselog/3_46_1.html) |
| Etcd | [v3.5.21-k3s1](https://github.com/k3s-io/etcd/releases/tag/v3.5.21-k3s1) |
| Containerd | [v2.0.4-k3s2](https://github.com/k3s-io/containerd/releases/tag/v2.0.4-k3s2) |
| Runc | [v1.2.5](https://github.com/opencontainers/runc/releases/tag/v1.2.5) |
| Flannel | [v0.26.7](https://github.com/flannel-io/flannel/releases/tag/v0.26.7) | 
| Metrics-server | [v0.7.2](https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.7.2) |
| Traefik | [v3.3.6](https://github.com/traefik/traefik/releases/tag/v3.3.6) |
| CoreDNS | [v1.12.1](https://github.com/coredns/coredns/releases/tag/v1.12.1) | 
| Helm-controller | [v0.16.10](https://github.com/k3s-io/helm-controller/releases/tag/v0.16.10) |
| Local-path-provisioner | [v0.0.31](https://github.com/rancher/local-path-provisioner/releases/tag/v0.0.31) |

## Helpful Links
As always, we welcome and appreciate feedback from our community of users. Please feel free to:
- [Open issues here](https://github.com/rancher/k3s/issues/new/choose)
- [Join our Slack channel](https://slack.rancher.io/)
- [Check out our documentation](https://rancher.com/docs/k3s/latest/en/) for guidance on how to get started or to dive deep into K3s.
- [Read how you can contribute here](https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md)