### PR TITLE
new release: k3s update from v1.33.4+k3s1 to v1.34.1+k3s1

### DIFF
--- a/inventory/cluster/group_vars/all.yml
+++ b/inventory/cluster/group_vars/all.yml
@@ -4,7 +4,7 @@ ansible_user: charles
 k3s_state: installed # 'uninstalled' to uninstall k3s
 k3s_pods_cidr: 10.42.0.0/16
 k3s_github_url: https://github.com/k3s-io/k3s
-k3s_release_version: v1.33.4+k3s1
+k3s_release_version: v1.34.1+k3s1
 k3s_become: true
 
 # Use etcd as an embedded datastore.


### PR DESCRIPTION
<!-- v1.34.1+k3s1 -->

This release updates Kubernetes to v1.34.1. This is the first k3s release in the 1.34 release line.

For more details on what's new, see the [Kubernetes release notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.34.md).

## Changes since v1.33.4+k3s1:

* Bump rancher libs: wrangler/lasso/remotedialer [(#12784)](https://github.com/k3s-io/k3s/pull/12784)
* Wire cri-dockerd `--log-level=debug` up to k3s `--debug` flag [(#12755)](https://github.com/k3s-io/k3s/pull/12755)
* Fix spegel logging and startup sequence [(#12796)](https://github.com/k3s-io/k3s/pull/12796)
* Update to runc v1.3.0 [(#12789)](https://github.com/k3s-io/k3s/pull/12789)
* Do not bootstrap etcd-only nodes from existing supervisor [(#12754)](https://github.com/k3s-io/k3s/pull/12754)
* Add retry on etcd MemberAdd timeout [(#12815)](https://github.com/k3s-io/k3s/pull/12815)
* Bump containerd to v2.1.4 [(#12788)](https://github.com/k3s-io/k3s/pull/12788)
* Retry CRD creation in case of conflict [(#12814)](https://github.com/k3s-io/k3s/pull/12814)
* Update stable to v1.33.4+k3s1 [(#12826)](https://github.com/k3s-io/k3s/pull/12826)
* Bump actions/checkout from 4 to 5 [(#12773)](https://github.com/k3s-io/k3s/pull/12773)
* Wire up kine metrics [(#12831)](https://github.com/k3s-io/k3s/pull/12831)
* Fix etcd join timeout handling [(#12833)](https://github.com/k3s-io/k3s/pull/12833)
* Wire up remotedialer metrics [(#12832)](https://github.com/k3s-io/k3s/pull/12832)
* Bump k3s-root to v0.15.0 [(#12853)](https://github.com/k3s-io/k3s/pull/12853)
  * The bundled userspace binaries are now built from the buildroot 2025.02 LTS branch.
  * The bundled nft binary now supports json output, required for compatibility with kube-proxy's nft proxier.
* Update to Kubernetes v1.34 [(#12854)](https://github.com/k3s-io/k3s/pull/12854)
* Add opencontainers/runc pin to v1.3.1 [(#12864)](https://github.com/k3s-io/k3s/pull/12864)
* Move data dir into position before creating CNI symlinks [(#12876)](https://github.com/k3s-io/k3s/pull/12876)
* Update to v1.34.1 and Go 1.24.6 [(#12896)](https://github.com/k3s-io/k3s/pull/12896)

## Embedded Component Versions
| Component | Version |
|---|---|
| Kubernetes | [v1.34.1](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.34.md#v1341) |
| Kine | [v0.14.0](https://github.com/k3s-io/kine/releases/tag/v0.14.0) |
| SQLite | [3.50.4](https://sqlite.org/releaselog/3_50_4.html) |
| Etcd | [v3.6.4-k3s3](https://github.com/k3s-io/etcd/releases/tag/v3.6.4-k3s3) |
| Containerd | [v2.1.4-k3s2](https://github.com/k3s-io/containerd/releases/tag/v2.1.4-k3s2) |
| Runc | [v1.3.1](https://github.com/opencontainers/runc/releases/tag/v1.3.1) |
| Flannel | [v0.27.0](https://github.com/flannel-io/flannel/releases/tag/v0.27.0) | 
| Metrics-server | [v0.8.0](https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.8.0) |
| Traefik | [v3.3.6](https://github.com/traefik/traefik/releases/tag/v3.3.6) |
| CoreDNS | [v1.12.3](https://github.com/coredns/coredns/releases/tag/v1.12.3) | 
| Helm-controller | [v0.16.13](https://github.com/k3s-io/helm-controller/releases/tag/v0.16.13) |
| Local-path-provisioner | [v0.0.32](https://github.com/rancher/local-path-provisioner/releases/tag/v0.0.32) |

## Helpful Links
As always, we welcome and appreciate feedback from our community of users. Please feel free to:
- [Open issues here](https://github.com/rancher/k3s/issues/new/choose)
- [Join our Slack channel](https://slack.rancher.io/)
- [Check out our documentation](https://rancher.com/docs/k3s/latest/en/) for guidance on how to get started or to dive deep into K3s.
- [Read how you can contribute here](https://github.com/rancher/k3s/blob/master/CONTRIBUTING.md)
