### PR TITLE
fix: install nvidia-dkms-570 to survive kernel updates

### DIFF
--- a/roles/nvidiaserver/tasks/main.yml
+++ b/roles/nvidiaserver/tasks/main.yml
@@ -18,6 +18,14 @@
   become: true
   ansible.builtin.command: ubuntu-drivers install nvidia:570 --gpgpu
 
+# ubuntu-drivers --gpgpu installs the no-dkms variant, which breaks on kernel updates.
+# Explicitly install DKMS so the nvidia module is rebuilt for new kernels.
+- name: Ensure NVIDIA DKMS module is installed
+  become: true
+  apt:
+    pkg:
+    - nvidia-dkms-570
+
 # NVIDIA Container Toolkit prerequisites
 - name: Download the NVIDIA repository GPG key if it does not exist
   shell: |


### PR DESCRIPTION
## Summary
- `ubuntu-drivers install nvidia:570 --gpgpu` installs `nvidia-headless-no-dkms-570`, which does not rebuild the kernel module when the kernel is updated
- This causes `nvidia-smi` to fail after kernel updates with "couldn't communicate with the NVIDIA driver"
- Explicitly installs `nvidia-dkms-570` so DKMS rebuilds the module for new kernels automatically